### PR TITLE
feat: gerenciamento de perfil (edição e alteração de senha)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# URL do backend
+VITE_API_URL=https://localhost:7188/api

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ package-lock.json
 *.njsproj
 *.sln
 *.sw?
+
+.env
+.env.local
+.env.*.local

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   },
   "dependencies": {
     "axios": "^1.11.0",
+    "date-fns": "^4.1.0",
     "js-cookie": "^3.0.5",
+    "jwt-decode": "^4.0.0",
     "material-design-icons-iconfont": "^6.7.0",
     "vue": "^3.5.18",
     "vue-router": "^4.5.1",
-    "zod": "^4.1.8",
-    "vuetify": "^3.1.15"
+    "vuetify": "^3.1.15",
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -8,7 +8,7 @@ const api = axios.create({
 api.interceptors.request.use((config) => {
   const token = getToken();
   if (token) {
-    config.headers.Authorization = token;
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { getToken } from "../services/authService";
 
 const api = axios.create({
-  baseURL: "https://localhost:7188/api",
+  baseURL: import.meta.env.VITE_API_URL,
 });
 
 api.interceptors.request.use((config) => {

--- a/src/components/atomicDesign/molecule/MoleculeCardInfo.vue
+++ b/src/components/atomicDesign/molecule/MoleculeCardInfo.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-card class="pa-6 mx-auto info-card" max-width="500" elevation="2">
+    <v-card-title v-if="title" class="text-h5 text-center">
+      <AtomText tag="h5">{{ title }}</AtomText>
+    </v-card-title>
+
+    <v-divider v-if="title" class="mb-4"></v-divider>
+
+    <v-card-text>
+      <div v-for="item in items" :key="item.label" class="info-row">
+        <AtomText tag="span" class="label">{{ item.label }}:</AtomText>
+
+        <template v-if="item.type === 'chip'">
+          <v-chip :color="item.color || 'primary'" small class="ml-2">
+            {{ item.value }}
+          </v-chip>
+        </template>
+
+        <template v-else-if="item.type === 'boolean'">
+          <v-chip :color="item.value ? 'green' : 'red'" small class="ml-2">
+            {{ item.value ? 'Active' : 'Inactive' }}
+          </v-chip>
+        </template>
+
+        <template v-else-if="item.type === 'date'">
+          <AtomText tag="span" class="value">{{ formatDate(item.value) }}</AtomText>
+        </template>
+
+        <template v-else>
+          <AtomText tag="span" class="value">{{ item.value }}</AtomText>
+        </template>
+      </div>
+    </v-card-text>
+
+    <v-card-actions class="justify-center">
+      <slot name="actions"></slot>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import AtomText from "../atom/AtomText.vue";
+import { format } from "date-fns";
+import type { InfoItem } from "../../../utils/types/cards";
+
+export default defineComponent({
+  name: "MoleculeCardInfo",
+  components: { AtomText },
+  props: {
+    title: { type: String, required: false },
+    items: { type: Array as () => InfoItem[], required: true },
+  },
+  methods: {
+    formatDate(date: string | Date) {
+      return format(new Date(date), "dd/MM/yyyy HH:mm");
+    },
+  },
+});
+</script>
+
+<style scoped>
+.info-card {
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.label {
+  font-weight: 500;
+  color: #555;
+}
+
+.value {
+  color: #333;
+}
+</style>

--- a/src/components/atomicDesign/molecule/MoleculeForm.vue
+++ b/src/components/atomicDesign/molecule/MoleculeForm.vue
@@ -1,10 +1,10 @@
 <template>
-  <v-card class="pa-4" width="40%">
+  <v-card class="pa-4" :width="width">
     <v-card-title>
       <AtomText tag="h1" class="text-h5">{{ pageTitle }}</AtomText>
     </v-card-title>
 
-    <v-card-title>
+    <v-card-title v-if="title">
       <AtomText tag="h2" class="text-h6">{{ title }}</AtomText>
     </v-card-title>
 
@@ -55,6 +55,7 @@ export default defineComponent({
     buttonText: { type: String, required: true },
     buttonTextColor: { type: String, default: "white" },
     buttonColor: { type: String, default: "primary" },
+    width: { type: String, default: "40%" },
     inputs: { type: Array as PropType<InputConfig[]>, required: true },
     values: { type: Object as PropType<Record<string, any>>, required: true },
     loading: { type: Boolean, required: true },

--- a/src/components/atomicDesign/organism/OrganismProfile.vue
+++ b/src/components/atomicDesign/organism/OrganismProfile.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="organism-profile">
+    <MoleculeCardInfo
+      :title="title"
+      :items="items"
+    >
+      <template #actions>
+        <AtomButton @click="onEditProfile">Editar Perfil</AtomButton>
+        <AtomButton @click="onChangePassword">Alterar Senha</AtomButton>
+      </template>
+    </MoleculeCardInfo>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from "vue";
+import MoleculeCardInfo from "../molecule/MoleculeCardInfo.vue";
+import AtomButton from "../atom/AtomButton.vue";
+import { useProfile } from "../../../composables/useProfile";
+import type { InfoItem } from "../../../utils/types/cards";
+
+export default defineComponent({
+  name: "OrganismProfile",
+  components: { MoleculeCardInfo, AtomButton },
+  props: { title: { type: String, default: "User Profile" } },
+  setup() {
+    const { user, loading } = useProfile(1);
+
+    const items = computed<InfoItem[]>(() =>
+      user.value
+        ? [
+            { label: "Nome", value: user.value.nome },
+            { label: "Email", value: user.value.email },
+            {
+              label: "Perfil",
+              value: user.value.perfil === 2 ? "Admin" : "User",
+              type: "chip",
+              color: user.value.perfil === 2 ? "purple" : "blue",
+            },
+            { label: "Status", value: user.value.status, type: "boolean" },
+            { label: "Criado em", value: user.value.dataCriacao, type: "date" },
+          ]
+        : []
+    );
+
+    const onEditProfile = () => console.log("Abrir modal de edição de perfil");
+    const onChangePassword = () => console.log("Abrir modal de alteração de senha");
+
+    return { items, loading, onEditProfile, onChangePassword };
+  },
+});
+</script>
+
+
+<style scoped>
+.organism-profile {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+</style>

--- a/src/components/atomicDesign/organism/OrganismProfile.vue
+++ b/src/components/atomicDesign/organism/OrganismProfile.vue
@@ -1,30 +1,72 @@
 <template>
   <div class="organism-profile">
-    <MoleculeCardInfo
-      :title="title"
-      :items="items"
-    >
+    <v-progress-circular v-if="loading && !user" indeterminate color="primary" class="mt-8" />
+
+    <v-alert v-else-if="error" type="error" class="mt-8" max-width="500">
+      {{ error }}
+    </v-alert>
+
+    <MoleculeCardInfo v-else :title="title" :items="items">
       <template #actions>
-        <AtomButton @click="onEditProfile">Editar Perfil</AtomButton>
-        <AtomButton @click="onChangePassword">Alterar Senha</AtomButton>
+        <AtomButton @click="openEditDialog">Editar Perfil</AtomButton>
+        <AtomButton @click="openPasswordDialog">Alterar Senha</AtomButton>
       </template>
     </MoleculeCardInfo>
+
+    <v-dialog v-model="editDialogOpen" max-width="450">
+      <MoleculeForm
+        pageTitle="Editar Perfil"
+        title=""
+        buttonText="Salvar"
+        width="100%"
+        :inputs="editProfileInputs"
+        :values="editValues"
+        :loading="editProfile.loading.value"
+        :isFormValid="editIsFormValid"
+        :onSubmit="editProfile.onSubmit"
+      />
+    </v-dialog>
+
+    <v-dialog v-model="passwordDialogOpen" max-width="450">
+      <MoleculeForm
+        pageTitle="Alterar Senha"
+        title=""
+        buttonText="Salvar"
+        width="100%"
+        :inputs="changePasswordInputs"
+        :values="passwordValues"
+        :loading="changePassword.loading.value"
+        :isFormValid="passwordIsFormValid"
+        :onSubmit="changePassword.onSubmit"
+      />
+    </v-dialog>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, ref } from "vue";
 import MoleculeCardInfo from "../molecule/MoleculeCardInfo.vue";
+import MoleculeForm from "../molecule/MoleculeForm.vue";
 import AtomButton from "../atom/AtomButton.vue";
 import { useProfile } from "../../../composables/useProfile";
+import { useEditProfileForm } from "../../../composables/useEditProfileForm";
+import { useChangePasswordForm } from "../../../composables/useChangePasswordForm";
+import { editProfileInputs, changePasswordInputs } from "../../../utils/configInputs";
 import type { InfoItem } from "../../../utils/types/cards";
+
+function isFormValid(inputs: { name: string }[], values: Record<string, any>): boolean {
+  return inputs.every((input) => {
+    const field = values[input.name];
+    return field.value && field.value.toString().trim() !== "";
+  });
+}
 
 export default defineComponent({
   name: "OrganismProfile",
-  components: { MoleculeCardInfo, AtomButton },
+  components: { MoleculeCardInfo, MoleculeForm, AtomButton },
   props: { title: { type: String, default: "User Profile" } },
   setup() {
-    const { user, loading } = useProfile(1);
+    const { user, loading, error, fetchUser } = useProfile();
 
     const items = computed<InfoItem[]>(() =>
       user.value
@@ -43,10 +85,61 @@ export default defineComponent({
         : []
     );
 
-    const onEditProfile = () => console.log("Abrir modal de edição de perfil");
-    const onChangePassword = () => console.log("Abrir modal de alteração de senha");
+    const editDialogOpen = ref(false);
+    const passwordDialogOpen = ref(false);
 
-    return { items, loading, onEditProfile, onChangePassword };
+    const editProfile = useEditProfileForm(user, () => {
+      editDialogOpen.value = false;
+      fetchUser();
+    });
+
+    const changePassword = useChangePasswordForm(user, () => {
+      passwordDialogOpen.value = false;
+      fetchUser();
+    });
+
+    const editValues = computed(() => ({
+      name: editProfile.name,
+      email: editProfile.email,
+      currentPassword: editProfile.currentPassword,
+    }));
+
+    const passwordValues = computed(() => ({
+      newPassword: changePassword.newPassword,
+      confirmNewPassword: changePassword.confirmNewPassword,
+    }));
+
+    const editIsFormValid = computed(() => isFormValid(editProfileInputs, editValues.value));
+    const passwordIsFormValid = computed(() => isFormValid(changePasswordInputs, passwordValues.value));
+
+    const openEditDialog = () => {
+      editProfile.resetForm();
+      editDialogOpen.value = true;
+    };
+
+    const openPasswordDialog = () => {
+      changePassword.resetForm();
+      passwordDialogOpen.value = true;
+    };
+
+    return {
+      user,
+      loading,
+      error,
+      items,
+      editDialogOpen,
+      passwordDialogOpen,
+      editProfile,
+      changePassword,
+      editValues,
+      passwordValues,
+      editProfileInputs,
+      changePasswordInputs,
+      editIsFormValid,
+      passwordIsFormValid,
+      openEditDialog,
+      openPasswordDialog,
+    };
   },
 });
 </script>
@@ -55,7 +148,8 @@ export default defineComponent({
 <style scoped>
 .organism-profile {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   margin-top: 20px;
 }
 </style>

--- a/src/composables/useChangePasswordForm.ts
+++ b/src/composables/useChangePasswordForm.ts
@@ -1,0 +1,30 @@
+import { ref, type Ref } from "vue";
+import { handleChangePassword } from "../services/usuarioHandlers";
+
+export function useChangePasswordForm(user: Ref<any>, onSuccess: () => void) {
+  const newPassword = ref("");
+  const confirmNewPassword = ref("");
+  const loading = ref(false);
+
+  const resetForm = () => {
+    newPassword.value = "";
+    confirmNewPassword.value = "";
+  };
+
+  const onSubmit = () =>
+    handleChangePassword(
+      user.value,
+      newPassword.value,
+      confirmNewPassword.value,
+      (val: boolean) => (loading.value = val),
+      onSuccess
+    );
+
+  return {
+    newPassword,
+    confirmNewPassword,
+    loading,
+    resetForm,
+    onSubmit,
+  };
+}

--- a/src/composables/useEditProfileForm.ts
+++ b/src/composables/useEditProfileForm.ts
@@ -1,0 +1,34 @@
+import { ref, type Ref } from "vue";
+import { handleEditProfile } from "../services/usuarioHandlers";
+
+export function useEditProfileForm(user: Ref<any>, onSuccess: () => void) {
+  const name = ref("");
+  const email = ref("");
+  const currentPassword = ref("");
+  const loading = ref(false);
+
+  const resetForm = () => {
+    name.value = user.value?.nome ?? "";
+    email.value = user.value?.email ?? "";
+    currentPassword.value = "";
+  };
+
+  const onSubmit = () =>
+    handleEditProfile(
+      user.value,
+      name.value,
+      email.value,
+      currentPassword.value,
+      (val: boolean) => (loading.value = val),
+      onSuccess
+    );
+
+  return {
+    name,
+    email,
+    currentPassword,
+    loading,
+    resetForm,
+    onSubmit,
+  };
+}

--- a/src/composables/useProfile.ts
+++ b/src/composables/useProfile.ts
@@ -1,12 +1,19 @@
 import { ref, onMounted } from "vue";
 import api from "../api/axios";
+import { getUserIdFromToken } from "../services/tokenService";
 
-export function useProfile(userId: number) {
+export function useProfile() {
   const user = ref<any>(null);
   const loading = ref(false);
   const error = ref<string | null>(null);
 
   const fetchUser = async () => {
+    const userId = getUserIdFromToken();
+    if (!userId) {
+      error.value = "Usuário não autenticado";
+      return;
+    }
+
     loading.value = true;
     error.value = null;
 

--- a/src/composables/useProfile.ts
+++ b/src/composables/useProfile.ts
@@ -1,0 +1,26 @@
+import { ref, onMounted } from "vue";
+import api from "../api/axios";
+
+export function useProfile(userId: number) {
+  const user = ref<any>(null);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  const fetchUser = async () => {
+    loading.value = true;
+    error.value = null;
+
+    try {
+      const response = await api.get(`/usuario/${userId}`);
+      user.value = response.data;
+    } catch (err: any) {
+      error.value = err.response?.data?.mensagem || "Erro ao carregar perfil";
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  onMounted(fetchUser);
+
+  return { user, loading, error, fetchUser };
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import HomeView from '../views/HomeView.vue';
 import LoginView from '../views/LoginView.vue';
 import RegisterView from '../views/RegisterView.vue';
 import PrincipalView from '../views/PrincipalView.vue';
+import ProfileView from '../views/ProfileView.vue';
 
 const routes = [
   { path: '/', redirect: '/login' },
@@ -13,7 +14,7 @@ const routes = [
     component: PrincipalView,
     children: [
       { path: 'home', name: 'Home', component: HomeView },
-      { path: 'perfil', name: 'Perfil', component: HomeView },
+      { path: 'perfil', name: 'Perfil', component: ProfileView },
       { path: 'alunos', name: 'Alunos', component: HomeView },
     ]
   },

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -1,0 +1,22 @@
+import { jwtDecode } from "jwt-decode";
+import { getToken } from "./authService";
+
+interface TokenPayload {
+  id: number;
+  email: string;
+  nome: string;
+  exp: number;
+}
+
+export function getUserIdFromToken(): number | null {
+  const token = getToken();
+  if (!token) return null;
+
+  try {
+    const decoded = jwtDecode<TokenPayload>(token);
+    return decoded.id;
+  } catch (error) {
+    console.error("Erro ao decodificar token:", error);
+    return null;
+  }
+}

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -2,9 +2,8 @@ import { jwtDecode } from "jwt-decode";
 import { getToken } from "./authService";
 
 interface TokenPayload {
-  id: number;
+  sub: string;
   email: string;
-  nome: string;
   exp: number;
 }
 
@@ -14,7 +13,7 @@ export function getUserIdFromToken(): number | null {
 
   try {
     const decoded = jwtDecode<TokenPayload>(token);
-    return decoded.id;
+    return Number(decoded.sub);
   } catch (error) {
     console.error("Erro ao decodificar token:", error);
     return null;

--- a/src/services/usuarioHandlers.ts
+++ b/src/services/usuarioHandlers.ts
@@ -1,0 +1,70 @@
+import { atualizarUsuario } from "./usuarioService";
+import { editProfileSchema, changePasswordSchema } from "../utils/validationSchema";
+
+type CurrentUser = {
+  id: number;
+  nome: string;
+  email: string;
+  perfil: number;
+  status: boolean;
+};
+
+function extractErrorMessage(err: any, fallback: string): string {
+  if (err?.errors) {
+    return "Erro no formulário: " + err.errors.map((e: any) => e.message).join(", ");
+  }
+  return fallback + ": " + (err.response?.data?.mensagem || err.message);
+}
+
+export const handleEditProfile = async (
+  currentUser: CurrentUser,
+  name: string,
+  email: string,
+  currentPassword: string,
+  setLoading: (val: boolean) => void,
+  onSuccess: () => void
+) => {
+  setLoading(true);
+  try {
+    editProfileSchema.parse({ name, email, currentPassword });
+    await atualizarUsuario({
+      id: currentUser.id,
+      nome: name,
+      email,
+      senha: currentPassword,
+      perfil: currentUser.perfil,
+      status: currentUser.status,
+    });
+    onSuccess();
+  } catch (err: any) {
+    alert(extractErrorMessage(err, "Falha ao atualizar perfil"));
+  } finally {
+    setLoading(false);
+  }
+};
+
+export const handleChangePassword = async (
+  currentUser: CurrentUser,
+  newPassword: string,
+  confirmNewPassword: string,
+  setLoading: (val: boolean) => void,
+  onSuccess: () => void
+) => {
+  setLoading(true);
+  try {
+    changePasswordSchema.parse({ newPassword, confirmNewPassword });
+    await atualizarUsuario({
+      id: currentUser.id,
+      nome: currentUser.nome,
+      email: currentUser.email,
+      senha: newPassword,
+      perfil: currentUser.perfil,
+      status: currentUser.status,
+    });
+    onSuccess();
+  } catch (err: any) {
+    alert(extractErrorMessage(err, "Falha ao alterar senha"));
+  } finally {
+    setLoading(false);
+  }
+};

--- a/src/services/usuarioService.ts
+++ b/src/services/usuarioService.ts
@@ -1,0 +1,15 @@
+import api from "../api/axios";
+
+export type UsuarioPayload = {
+  id: number;
+  nome: string;
+  email: string;
+  senha: string;
+  perfil: number;
+  status: boolean;
+};
+
+export async function atualizarUsuario(payload: UsuarioPayload) {
+  const response = await api.put("/usuario", payload);
+  return response.data;
+}

--- a/src/utils/configInputs.ts
+++ b/src/utils/configInputs.ts
@@ -1,4 +1,4 @@
-import { loginSchema, registerSchema, makeRule } from "../utils/validationSchema";
+import { loginSchema, registerSchema, editProfileSchema, changePasswordBaseSchema, makeRule } from "../utils/validationSchema";
 
 export const loginInputs = [
   { name: "email", type: "text", placeholder: "Email", rules: [makeRule(loginSchema, "email")] },
@@ -10,4 +10,15 @@ export const registerInputs = [
   { name: "email", type: "email", placeholder: "Email", rules: [makeRule(registerSchema, "email")] },
   { name: "password", type: "password", placeholder: "Senha", rules: [makeRule(registerSchema, "password")] },
   { name: "confirmPassword", type: "password", placeholder: "Confirmar Senha", rules: [makeRule(registerSchema, "confirmPassword")] },
+];
+
+export const editProfileInputs = [
+  { name: "name", type: "text", placeholder: "Nome", rules: [makeRule(editProfileSchema, "name")] },
+  { name: "email", type: "email", placeholder: "Email", rules: [makeRule(editProfileSchema, "email")] },
+  { name: "currentPassword", type: "password", placeholder: "Senha atual", rules: [makeRule(editProfileSchema, "currentPassword")] },
+];
+
+export const changePasswordInputs = [
+  { name: "newPassword", type: "password", placeholder: "Nova senha", rules: [makeRule(changePasswordBaseSchema, "newPassword")] },
+  { name: "confirmNewPassword", type: "password", placeholder: "Confirmar nova senha", rules: [makeRule(changePasswordBaseSchema, "confirmNewPassword")] },
 ];

--- a/src/utils/types/cards.ts
+++ b/src/utils/types/cards.ts
@@ -1,0 +1,6 @@
+export type InfoItem = {
+  label: string;
+  value: any;
+  type?: "text" | "chip" | "boolean" | "date";
+  color?: string;
+};

--- a/src/utils/validationSchema.ts
+++ b/src/utils/validationSchema.ts
@@ -38,5 +38,23 @@ export function makeRule<
   };
 }
 
+export const editProfileSchema = z.object({
+  name: z.string().nonempty("O nome é obrigatório"),
+  email: z.string().nonempty("O e-mail é obrigatório").email("E-mail inválido"),
+  currentPassword: z.string().nonempty("Confirme sua senha atual para salvar"),
+});
+
+export const changePasswordBaseSchema = z.object({
+  newPassword: loginSchema.shape.password,
+  confirmNewPassword: z.string().nonempty("Confirmação de senha obrigatória"),
+});
+
+export const changePasswordSchema = changePasswordBaseSchema.refine(
+  (data) => data.newPassword === data.confirmNewPassword,
+  { path: ["confirmNewPassword"], message: "As senhas não coincidem" }
+);
+
 export type LoginSchema = z.infer<typeof loginSchema>;
 export type RegisterSchema = z.infer<typeof registerSchema>;
+export type EditProfileSchema = z.infer<typeof editProfileSchema>;
+export type ChangePasswordSchema = z.infer<typeof changePasswordSchema>;

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -1,0 +1,13 @@
+<template>
+  <OrganismProfile title="Perfil" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import OrganismProfile from '../components/atomicDesign/organism/OrganismProfile.vue';
+
+export default defineComponent({
+  name: 'ProfileView',
+  components: { OrganismProfile }
+});
+</script>


### PR DESCRIPTION
## Resumo
- Usa o id do usuário logado (via claim `sub` do JWT) em vez de id fixo pra carregar o perfil
- Implementa edição de perfil (nome/email) e alteração de senha, reaproveitando o único endpoint `PUT /api/usuario` que a API expõe
- Corrige autenticação JWT no front: claim do token estava errada (`id` → `sub`) e faltava o prefixo `Bearer` no header `Authorization`
- Adiciona suporte a largura customizável no `MoleculeForm` pra ele poder ser reaproveitado dentro de diálogos

## Commits
- fix: corrige autenticação jwt no front (claim do token e header bearer)
- feat: usa id do usuário logado no lugar do id fixo no perfil
- feat: adiciona suporte a largura customizada no molecula form
- feat: adiciona validações e configuração de inputs para edição de perfil e troca de senha
- feat: adiciona service e handlers de atualização de usuário
- feat: implementa edição de perfil e alteração de senha