### PR TITLE
feat: guardas de rota (autenticação e restrição por perfil)

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
-import { getToken } from "../services/authService";
+import { getToken, logout } from "../services/authService";
+import router from "../router";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -12,5 +13,17 @@ api.interceptors.request.use((config) => {
   }
   return config;
 });
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const isLoginRequest = error.config?.url?.includes("/login");
+    if (error.response?.status === 401 && !isLoginRequest) {
+      logout();
+      router.push("/login");
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/src/composables/useOrganismPrincipalLayout.ts
+++ b/src/composables/useOrganismPrincipalLayout.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 import { useRouter, type RouteLocationRaw } from "vue-router";
 import { handleLogout } from "../services/authHandlers";
 import { menuItens } from "../utils/navigation";
+import { getUserRoleFromToken } from "../services/tokenService";
 
 export function useOrganismPrincipalLayout() {
   const drawerOpen = ref(false);
@@ -20,7 +21,9 @@ export function useOrganismPrincipalLayout() {
     });
   };
 
-  const navigationItens = menuItens;
+  const navigationItens = menuItens.filter(
+    (item) => !item.adminOnly || getUserRoleFromToken() === "ADMIN"
+  );
 
   const navigateTo = async (rota: RouteLocationRaw) => {
     try {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import LoginView from '../views/LoginView.vue';
 import RegisterView from '../views/RegisterView.vue';
 import PrincipalView from '../views/PrincipalView.vue';
 import ProfileView from '../views/ProfileView.vue';
+import { isTokenExpired, getUserRoleFromToken } from '../services/tokenService';
 
 const routes = [
   { path: '/', redirect: '/login' },
@@ -12,10 +13,11 @@ const routes = [
   {
     path: '/',
     component: PrincipalView,
+    meta: { requiresAuth: true },
     children: [
       { path: 'home', name: 'Home', component: HomeView },
       { path: 'perfil', name: 'Perfil', component: ProfileView },
-      { path: 'alunos', name: 'Alunos', component: HomeView },
+      { path: 'alunos', name: 'Alunos', component: HomeView, meta: { requiresAdmin: true } },
     ]
   },
 ];
@@ -23,6 +25,18 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
+});
+
+router.beforeEach((to) => {
+  if (to.matched.some((record) => record.meta.requiresAuth) && isTokenExpired()) {
+    return '/login';
+  }
+
+  if (to.matched.some((record) => record.meta.requiresAdmin) && getUserRoleFromToken() !== 'ADMIN') {
+    return '/home';
+  }
+
+  return true;
 });
 
 export default router;

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -1,21 +1,43 @@
 import { jwtDecode } from "jwt-decode";
 import { getToken } from "./authService";
 
+// A API monta o claim de perfil com Claim(ClaimTypes.Role, ...) e escreve o token
+// direto via `new JwtSecurityToken(issuer, audience, claims, ...)`, sem mapeamento
+// outbound — por isso a chave no payload é a URI completa, não "role".
+const ROLE_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
+
 interface TokenPayload {
   sub: string;
   email: string;
   exp: number;
+  [claim: string]: unknown;
 }
 
-export function getUserIdFromToken(): number | null {
+function decodeToken(): TokenPayload | null {
   const token = getToken();
   if (!token) return null;
 
   try {
-    const decoded = jwtDecode<TokenPayload>(token);
-    return Number(decoded.sub);
+    return jwtDecode<TokenPayload>(token);
   } catch (error) {
     console.error("Erro ao decodificar token:", error);
     return null;
   }
+}
+
+export function getUserIdFromToken(): number | null {
+  const decoded = decodeToken();
+  return decoded ? Number(decoded.sub) : null;
+}
+
+export function getUserRoleFromToken(): string | null {
+  const decoded = decodeToken();
+  return (decoded?.[ROLE_CLAIM] as string) ?? null;
+}
+
+export function isTokenExpired(): boolean {
+  const decoded = decodeToken();
+  if (!decoded) return true;
+
+  return decoded.exp * 1000 < Date.now();
 }

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -3,5 +3,5 @@ import type { MenuItem } from "./types/menu";
 export const menuItens: MenuItem[] = [
   { text: 'Home', route: { name: 'Home'}, icon: 'home' },
   { text: 'Perfil', route: { name: 'Perfil' }, icon: 'person' },
-  { text: 'Alunos', route: { name: 'Alunos' }, icon: 'people' },
+  { text: 'Alunos', route: { name: 'Alunos' }, icon: 'people', adminOnly: true },
 ];

--- a/src/utils/types/menu.ts
+++ b/src/utils/types/menu.ts
@@ -4,4 +4,5 @@ export type MenuItem = {
   text: string;
   icon?: string;
   route: RouteLocationRaw;
+  adminOnly?: boolean;
 };


### PR DESCRIPTION
## Resumo
- Adiciona `router.beforeEach` que redireciona para `/login` quando não há token válido
- Bloqueia acesso direto (via URL) à rota `/alunos` para usuários com perfil `USER` — só `ADMIN` acessa, espelhando a restrição que já existe na API
- Esconde o item "Alunos" do menu lateral para usuários não admin
- Trata erro 401 global no interceptor do axios: desloga e redireciona para `/login` quando o token expira ou é rejeitado pela API (exceto no próprio endpoint de login, pra não interferir na mensagem de credenciais inválidas)

## Nota técnica
A claim de perfil no JWT vem com a chave completa `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role` (não `"role"`), porque a API monta o token direto via `new JwtSecurityToken(...)` com `ClaimTypes.Role`, sem mapeamento outbound de nome curto. `getUserRoleFromToken()` em `tokenService.ts` já lida com isso — documentado em comentário no próprio arquivo.

## Commits
- feat: adiciona leitura de perfil e expiração do token
- feat: implementa guarda de autenticação e de perfil no router
- feat: trata erro 401 global no interceptor do axios
- feat: esconde item de menu de alunos para usuários não admin