### PR TITLE
feat: gerenciamento de alunos (listagem, cadastro, edição e exclusão)

### DIFF
--- a/src/components/atomicDesign/molecule/MoleculeAlunosTable.vue
+++ b/src/components/atomicDesign/molecule/MoleculeAlunosTable.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-table class="alunos-table">
+    <thead>
+      <tr>
+        <th>Nome</th>
+        <th>Email</th>
+        <th>Curso</th>
+        <th>Data de Nascimento</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="aluno in alunos" :key="aluno.id">
+        <td><AtomText tag="span">{{ aluno.nome }}</AtomText></td>
+        <td><AtomText tag="span">{{ aluno.email }}</AtomText></td>
+        <td><AtomText tag="span">{{ aluno.curso }}</AtomText></td>
+        <td><AtomText tag="span">{{ formatDate(aluno.dataNascimento) }}</AtomText></td>
+        <td class="acoes">
+          <AtomButton buttonColor="primary" @click="$emit('editar', aluno)">Editar</AtomButton>
+          <AtomButton buttonColor="red" @click="$emit('excluir', aluno)">Excluir</AtomButton>
+        </td>
+      </tr>
+    </tbody>
+  </v-table>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from "vue";
+import AtomText from "../atom/AtomText.vue";
+import AtomButton from "../atom/AtomButton.vue";
+import { format } from "date-fns";
+import type { Aluno } from "../../../utils/types/aluno";
+
+export default defineComponent({
+  name: "MoleculeAlunosTable",
+  components: { AtomText, AtomButton },
+  props: {
+    alunos: { type: Array as PropType<Aluno[]>, required: true },
+  },
+  emits: ["editar", "excluir"],
+  methods: {
+    formatDate(date: string) {
+      // Data de nascimento é uma data de calendário, não um instante — extrai os
+      // componentes direto da string e monta em horário local pra não sofrer
+      // deslocamento de fuso (new Date("yyyy-MM-dd") é interpretado como UTC).
+      const [year, month, day] = date.slice(0, 10).split("-").map(Number);
+      return format(new Date(year, month - 1, day), "dd/MM/yyyy");
+    },
+  },
+});
+</script>
+
+<style scoped>
+.alunos-table {
+  width: 100%;
+}
+
+.acoes {
+  display: flex;
+  gap: 8px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+</style>

--- a/src/components/atomicDesign/organism/OrganismAlunos.vue
+++ b/src/components/atomicDesign/organism/OrganismAlunos.vue
@@ -1,0 +1,205 @@
+<template>
+  <div class="organism-alunos">
+    <div class="filtros">
+      <AtomInput v-model="nomeFiltro" type="text" placeholder="Buscar por nome" class="filtro-input" />
+      <AtomInput v-model="cursoFiltro" type="text" placeholder="Buscar por curso" class="filtro-input" />
+      <AtomButton @click="buscar">Buscar</AtomButton>
+      <AtomButton buttonColor="#006400" @click="openCreateDialog">Novo Aluno</AtomButton>
+    </div>
+
+    <v-progress-circular v-if="loading && alunos.length === 0" indeterminate color="primary" class="mt-8" />
+
+    <v-alert v-else-if="error" type="error" class="mt-4">
+      {{ error }}
+    </v-alert>
+
+    <template v-else>
+      <v-alert v-if="alunos.length === 0" type="info" class="mt-4">
+        {{ mensagemListaVazia }}
+      </v-alert>
+
+      <MoleculeAlunosTable
+        v-else
+        :alunos="alunos"
+        @editar="openEditDialog"
+        @excluir="openDeleteDialog"
+      />
+
+      <div class="paginacao">
+        <AtomButton :disabled="pagina === 0" @click="paginaAnterior">Anterior</AtomButton>
+        <AtomButton :disabled="!temProximaPagina" @click="proximaPagina">Próxima</AtomButton>
+      </div>
+    </template>
+
+    <v-dialog v-model="formDialogOpen" max-width="450">
+      <MoleculeForm
+        :pageTitle="formTitle"
+        title=""
+        buttonText="Salvar"
+        width="100%"
+        :inputs="alunoInputs"
+        :values="formValues"
+        :loading="alunoForm.loading.value"
+        :isFormValid="formIsValid"
+        :onSubmit="alunoForm.onSubmit"
+      />
+    </v-dialog>
+
+    <v-dialog v-model="deleteDialogOpen" max-width="400">
+      <v-card class="pa-4">
+        <v-card-title>Excluir aluno</v-card-title>
+        <v-card-text>
+          Tem certeza que deseja excluir {{ alunoParaExcluir?.nome }}?
+        </v-card-text>
+        <v-card-actions>
+          <AtomButton @click="deleteDialogOpen = false">Cancelar</AtomButton>
+          <AtomButton buttonColor="red" :loading="deleting" @click="confirmarExclusao">Excluir</AtomButton>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, ref } from "vue";
+import MoleculeAlunosTable from "../molecule/MoleculeAlunosTable.vue";
+import MoleculeForm from "../molecule/MoleculeForm.vue";
+import AtomButton from "../atom/AtomButton.vue";
+import AtomInput from "../atom/AtomInput.vue";
+import { useAlunosList } from "../../../composables/useAlunosList";
+import { useAlunoForm } from "../../../composables/useAlunoForm";
+import { handleDeletarAluno } from "../../../services/alunoHandlers";
+import { alunoInputs } from "../../../utils/configInputs";
+import { isFormValid } from "../../../utils/formValidation";
+import type { Aluno } from "../../../utils/types/aluno";
+
+export default defineComponent({
+  name: "OrganismAlunos",
+  components: { MoleculeAlunosTable, MoleculeForm, AtomButton, AtomInput },
+  setup() {
+    const {
+      alunos,
+      loading,
+      error,
+      nomeFiltro,
+      cursoFiltro,
+      pagina,
+      temProximaPagina,
+      fetchAlunos,
+      buscar,
+      proximaPagina,
+      paginaAnterior,
+    } = useAlunosList();
+
+    fetchAlunos();
+
+    const mensagemListaVazia = computed(() => {
+      if (nomeFiltro.value || cursoFiltro.value) {
+        return "Nenhum aluno encontrado para esse filtro.";
+      }
+      if (pagina.value > 0) {
+        return "Não há mais alunos para exibir.";
+      }
+      return "Nenhum aluno cadastrado ainda.";
+    });
+
+    const formDialogOpen = ref(false);
+
+    const alunoForm = useAlunoForm(() => {
+      formDialogOpen.value = false;
+      fetchAlunos();
+    });
+
+    const formValues = computed(() => ({
+      nome: alunoForm.nome,
+      email: alunoForm.email,
+      curso: alunoForm.curso,
+      dataNascimento: alunoForm.dataNascimento,
+    }));
+
+    const formIsValid = computed(() => isFormValid(alunoInputs, formValues.value));
+    const formTitle = computed(() => (alunoForm.id.value ? "Editar Aluno" : "Novo Aluno"));
+
+    const openCreateDialog = () => {
+      alunoForm.resetForm();
+      formDialogOpen.value = true;
+    };
+
+    const openEditDialog = (aluno: Aluno) => {
+      alunoForm.resetForm(aluno);
+      formDialogOpen.value = true;
+    };
+
+    const deleteDialogOpen = ref(false);
+    const alunoParaExcluir = ref<Aluno | null>(null);
+    const deleting = ref(false);
+
+    const openDeleteDialog = (aluno: Aluno) => {
+      alunoParaExcluir.value = aluno;
+      deleteDialogOpen.value = true;
+    };
+
+    const confirmarExclusao = () => {
+      if (!alunoParaExcluir.value) return;
+      handleDeletarAluno(alunoParaExcluir.value.id, (val) => (deleting.value = val), () => {
+        deleteDialogOpen.value = false;
+        fetchAlunos();
+      });
+    };
+
+    return {
+      alunos,
+      loading,
+      error,
+      nomeFiltro,
+      cursoFiltro,
+      pagina,
+      temProximaPagina,
+      buscar,
+      proximaPagina,
+      paginaAnterior,
+      mensagemListaVazia,
+      formDialogOpen,
+      alunoForm,
+      formValues,
+      formIsValid,
+      formTitle,
+      alunoInputs,
+      openCreateDialog,
+      openEditDialog,
+      deleteDialogOpen,
+      alunoParaExcluir,
+      deleting,
+      openDeleteDialog,
+      confirmarExclusao,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.organism-alunos {
+  width: 100%;
+  max-width: 900px;
+  margin: 20px auto;
+}
+
+.filtros {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.filtro-input {
+  max-width: 220px;
+}
+
+.paginacao {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 16px;
+}
+</style>

--- a/src/components/atomicDesign/organism/OrganismProfile.vue
+++ b/src/components/atomicDesign/organism/OrganismProfile.vue
@@ -52,14 +52,8 @@ import { useProfile } from "../../../composables/useProfile";
 import { useEditProfileForm } from "../../../composables/useEditProfileForm";
 import { useChangePasswordForm } from "../../../composables/useChangePasswordForm";
 import { editProfileInputs, changePasswordInputs } from "../../../utils/configInputs";
+import { isFormValid } from "../../../utils/formValidation";
 import type { InfoItem } from "../../../utils/types/cards";
-
-function isFormValid(inputs: { name: string }[], values: Record<string, any>): boolean {
-  return inputs.every((input) => {
-    const field = values[input.name];
-    return field.value && field.value.toString().trim() !== "";
-  });
-}
 
 export default defineComponent({
   name: "OrganismProfile",

--- a/src/composables/useAlunoForm.ts
+++ b/src/composables/useAlunoForm.ts
@@ -1,0 +1,38 @@
+import { ref } from "vue";
+import { handleSalvarAluno } from "../services/alunoHandlers";
+import type { Aluno } from "../utils/types/aluno";
+
+export function useAlunoForm(onSuccess: () => void) {
+  const id = ref<number | undefined>(undefined);
+  const nome = ref("");
+  const email = ref("");
+  const curso = ref("");
+  const dataNascimento = ref("");
+  const status = ref(true);
+  const loading = ref(false);
+
+  const resetForm = (aluno?: Aluno) => {
+    id.value = aluno?.id;
+    nome.value = aluno?.nome ?? "";
+    email.value = aluno?.email ?? "";
+    curso.value = aluno?.curso ?? "";
+    dataNascimento.value = aluno?.dataNascimento?.slice(0, 10) ?? "";
+    status.value = aluno?.status ?? true;
+  };
+
+  const onSubmit = () =>
+    handleSalvarAluno(
+      {
+        id: id.value,
+        nome: nome.value,
+        email: email.value,
+        curso: curso.value,
+        dataNascimento: dataNascimento.value,
+        status: status.value,
+      },
+      (val: boolean) => (loading.value = val),
+      onSuccess
+    );
+
+  return { id, nome, email, curso, dataNascimento, status, loading, resetForm, onSubmit };
+}

--- a/src/composables/useAlunosList.ts
+++ b/src/composables/useAlunosList.ts
@@ -1,0 +1,66 @@
+import { ref } from "vue";
+import { handleListarAlunos } from "../services/alunoHandlers";
+import type { Aluno } from "../utils/types/aluno";
+
+export const QUANTIDADE_POR_PAGINA = 10;
+
+export function useAlunosList() {
+  const alunos = ref<Aluno[]>([]);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+  const nomeFiltro = ref("");
+  const cursoFiltro = ref("");
+  const pagina = ref(0);
+  const temProximaPagina = ref(false);
+
+  const fetchAlunos = () => {
+    handleListarAlunos(
+      {
+        nome: nomeFiltro.value || undefined,
+        curso: cursoFiltro.value || undefined,
+        pular: pagina.value * QUANTIDADE_POR_PAGINA,
+        // pede 1 a mais só pra descobrir se existe próxima página, sem exibir esse extra
+        quantidade: QUANTIDADE_POR_PAGINA + 1,
+      },
+      (val) => (loading.value = val),
+      (data) => {
+        temProximaPagina.value = data.length > QUANTIDADE_POR_PAGINA;
+        alunos.value = data.slice(0, QUANTIDADE_POR_PAGINA);
+        error.value = null;
+      },
+      (mensagem) => {
+        error.value = mensagem;
+      }
+    );
+  };
+
+  const buscar = () => {
+    pagina.value = 0;
+    fetchAlunos();
+  };
+
+  const proximaPagina = () => {
+    pagina.value += 1;
+    fetchAlunos();
+  };
+
+  const paginaAnterior = () => {
+    if (pagina.value === 0) return;
+    pagina.value -= 1;
+    fetchAlunos();
+  };
+
+  return {
+    alunos,
+    loading,
+    error,
+    nomeFiltro,
+    cursoFiltro,
+    pagina,
+    temProximaPagina,
+    fetchAlunos,
+    buscar,
+    proximaPagina,
+    paginaAnterior,
+  };
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import LoginView from '../views/LoginView.vue';
 import RegisterView from '../views/RegisterView.vue';
 import PrincipalView from '../views/PrincipalView.vue';
 import ProfileView from '../views/ProfileView.vue';
+import AlunosView from '../views/AlunosView.vue';
 import { isTokenExpired, getUserRoleFromToken } from '../services/tokenService';
 
 const routes = [
@@ -17,7 +18,7 @@ const routes = [
     children: [
       { path: 'home', name: 'Home', component: HomeView },
       { path: 'perfil', name: 'Perfil', component: ProfileView },
-      { path: 'alunos', name: 'Alunos', component: HomeView, meta: { requiresAdmin: true } },
+      { path: 'alunos', name: 'Alunos', component: AlunosView, meta: { requiresAdmin: true } },
     ]
   },
 ];

--- a/src/services/alunoHandlers.ts
+++ b/src/services/alunoHandlers.ts
@@ -1,0 +1,76 @@
+import { listarAlunos, criarAluno, atualizarAluno, deletarAluno } from "./alunoService";
+import type { AlunoFiltros, AlunoPayload } from "./alunoService";
+import type { Aluno } from "../utils/types/aluno";
+import { alunoSchema } from "../utils/validationSchema";
+
+function extractErrorMessage(err: any, fallback: string): string {
+  if (err?.errors) {
+    return "Erro no formulário: " + err.errors.map((e: any) => e.message).join(", ");
+  }
+  return fallback + ": " + (err.response?.data?.mensagem || err.message);
+}
+
+export const handleListarAlunos = async (
+  filtros: AlunoFiltros,
+  setLoading: (val: boolean) => void,
+  onSuccess: (alunos: Aluno[]) => void,
+  onError: (mensagem: string) => void
+) => {
+  setLoading(true);
+  try {
+    const alunos = await listarAlunos(filtros);
+    onSuccess(alunos);
+  } catch (err: any) {
+    // A API retorna 404 quando a busca não encontra nenhum aluno — não é um erro, é lista vazia.
+    if (err.response?.status === 404) {
+      onSuccess([]);
+    } else {
+      onError(err.response?.data?.mensagem || "Erro ao carregar alunos");
+    }
+  } finally {
+    setLoading(false);
+  }
+};
+
+export const handleSalvarAluno = async (
+  payload: AlunoPayload,
+  setLoading: (val: boolean) => void,
+  onSuccess: () => void
+) => {
+  setLoading(true);
+  try {
+    alunoSchema.parse({
+      nome: payload.nome,
+      email: payload.email,
+      curso: payload.curso,
+      dataNascimento: payload.dataNascimento,
+    });
+
+    if (payload.id) {
+      await atualizarAluno(payload);
+    } else {
+      await criarAluno(payload);
+    }
+    onSuccess();
+  } catch (err: any) {
+    alert(extractErrorMessage(err, "Falha ao salvar aluno"));
+  } finally {
+    setLoading(false);
+  }
+};
+
+export const handleDeletarAluno = async (
+  id: number,
+  setLoading: (val: boolean) => void,
+  onSuccess: () => void
+) => {
+  setLoading(true);
+  try {
+    await deletarAluno(id);
+    onSuccess();
+  } catch (err: any) {
+    alert(extractErrorMessage(err, "Falha ao excluir aluno"));
+  } finally {
+    setLoading(false);
+  }
+};

--- a/src/services/alunoService.ts
+++ b/src/services/alunoService.ts
@@ -1,0 +1,38 @@
+import api from "../api/axios";
+import type { Aluno } from "../utils/types/aluno";
+
+export type AlunoFiltros = {
+  nome?: string;
+  curso?: string;
+  pular?: number;
+  quantidade?: number;
+};
+
+export type AlunoPayload = {
+  id?: number;
+  nome: string;
+  email: string;
+  dataNascimento: string;
+  curso: string;
+  status?: boolean;
+};
+
+export async function listarAlunos(filtros: AlunoFiltros): Promise<Aluno[]> {
+  const response = await api.get("/aluno", { params: filtros });
+  return response.data;
+}
+
+export async function criarAluno(payload: AlunoPayload): Promise<Aluno> {
+  const response = await api.post("/aluno", payload);
+  return response.data;
+}
+
+export async function atualizarAluno(payload: AlunoPayload): Promise<Aluno> {
+  const response = await api.put("/aluno", payload);
+  return response.data;
+}
+
+export async function deletarAluno(id: number): Promise<Aluno> {
+  const response = await api.delete(`/aluno/${id}`);
+  return response.data;
+}

--- a/src/services/authHandlers.ts
+++ b/src/services/authHandlers.ts
@@ -12,7 +12,7 @@ export const handleLogin = async (email: string, password: string, setLoading: (
     if (err?.errors) {
       alert("Erro no formulário: " + err.errors.map((e: any) => e.message).join(", "));
     } else {
-      alert("Falha no login: " + (err.response?.data?.message || err.message));
+      alert("Falha no login: " + (err.response?.data?.mensagem || err.message));
     }
   } finally {
     setLoading(false);
@@ -35,7 +35,7 @@ export const handleRegister = async (
     if (err?.errors) {
       alert("Erro no formulário: " + err.errors.map((e: any) => e.message).join(", "));
     } else {
-      alert("Falha no cadastro: " + (err.response?.data?.message || err.message));
+      alert("Falha no cadastro: " + (err.response?.data?.mensagem || err.message));
     }
   } finally {
     setLoading(false);
@@ -48,7 +48,7 @@ export const handleLogout = (setLoading: (val: boolean) => void) => {
     logout();
     router.push("/login");
   } catch (err: any) {
-    alert("Falha ao deslogar: " + (err.response?.data?.message || err.message));
+    alert("Falha ao deslogar: " + (err.response?.data?.mensagem || err.message));
   } finally {
     setLoading(false);
   }

--- a/src/utils/configInputs.ts
+++ b/src/utils/configInputs.ts
@@ -1,4 +1,4 @@
-import { loginSchema, registerSchema, editProfileSchema, changePasswordBaseSchema, makeRule } from "../utils/validationSchema";
+import { loginSchema, registerSchema, editProfileSchema, changePasswordBaseSchema, alunoSchema, makeRule } from "../utils/validationSchema";
 
 export const loginInputs = [
   { name: "email", type: "text", placeholder: "Email", rules: [makeRule(loginSchema, "email")] },
@@ -21,4 +21,11 @@ export const editProfileInputs = [
 export const changePasswordInputs = [
   { name: "newPassword", type: "password", placeholder: "Nova senha", rules: [makeRule(changePasswordBaseSchema, "newPassword")] },
   { name: "confirmNewPassword", type: "password", placeholder: "Confirmar nova senha", rules: [makeRule(changePasswordBaseSchema, "confirmNewPassword")] },
+];
+
+export const alunoInputs = [
+  { name: "nome", type: "text", placeholder: "Nome", rules: [makeRule(alunoSchema, "nome")] },
+  { name: "email", type: "email", placeholder: "Email", rules: [makeRule(alunoSchema, "email")] },
+  { name: "curso", type: "text", placeholder: "Curso", rules: [makeRule(alunoSchema, "curso")] },
+  { name: "dataNascimento", type: "date", placeholder: "Data de Nascimento", rules: [makeRule(alunoSchema, "dataNascimento")] },
 ];

--- a/src/utils/formValidation.ts
+++ b/src/utils/formValidation.ts
@@ -1,0 +1,6 @@
+export function isFormValid(inputs: { name: string }[], values: Record<string, { value: any }>): boolean {
+  return inputs.every((input) => {
+    const field = values[input.name];
+    return field.value && field.value.toString().trim() !== "";
+  });
+}

--- a/src/utils/types/aluno.ts
+++ b/src/utils/types/aluno.ts
@@ -1,0 +1,10 @@
+export type Aluno = {
+  id: number;
+  nome: string;
+  email: string;
+  dataNascimento: string;
+  curso: string;
+  status: boolean;
+  dataCriacao: string;
+  dataAtualizacao: string;
+};

--- a/src/utils/validationSchema.ts
+++ b/src/utils/validationSchema.ts
@@ -54,7 +54,18 @@ export const changePasswordSchema = changePasswordBaseSchema.refine(
   { path: ["confirmNewPassword"], message: "As senhas não coincidem" }
 );
 
+export const alunoSchema = z.object({
+  nome: z.string().nonempty("O nome é obrigatório"),
+  email: z.string().nonempty("O e-mail é obrigatório").email("E-mail inválido"),
+  curso: z.string().nonempty("O curso é obrigatório"),
+  dataNascimento: z
+    .string()
+    .nonempty("A data de nascimento é obrigatória")
+    .refine((val) => new Date(val) <= new Date(), "A data de nascimento não pode ser futura"),
+});
+
 export type LoginSchema = z.infer<typeof loginSchema>;
 export type RegisterSchema = z.infer<typeof registerSchema>;
 export type EditProfileSchema = z.infer<typeof editProfileSchema>;
 export type ChangePasswordSchema = z.infer<typeof changePasswordSchema>;
+export type AlunoSchema = z.infer<typeof alunoSchema>;

--- a/src/views/AlunosView.vue
+++ b/src/views/AlunosView.vue
@@ -1,0 +1,13 @@
+<template>
+  <OrganismAlunos />
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import OrganismAlunos from '../components/atomicDesign/organism/OrganismAlunos.vue';
+
+export default defineComponent({
+  name: 'AlunosView',
+  components: { OrganismAlunos }
+});
+</script>


### PR DESCRIPTION
## Resumo
- Implementa a última lacuna funcional do sistema: telas de gerenciamento de alunos, consumindo o CRUD que a API já tinha pronto
- Listagem com filtro por nome/curso e paginação (`pular`/`quantidade`)
- Cadastro e edição via formulário reaproveitando `MoleculeForm`
- Exclusão (soft delete) com dialog de confirmação
- 404 da API (busca sem resultado) tratado como lista vazia, com mensagens diferentes conforme o contexto: filtro sem resultado, fim da paginação, ou nenhum aluno cadastrado ainda
- Paginação "peek-ahead": pede 1 item a mais do que exibe pra saber de antemão se existe próxima página, em vez de deixar o usuário clicar numa página vazia
- Hotfix embutido (a pedido, fora do padrão de uma branch por task): `authHandlers.ts` lia `err.response?.data?.message` em vez de `.mensagem`, fazendo erros de login/cadastro aparecerem como `undefined`
- Refactor: `isFormValid` extraído pra `utils/formValidation.ts`, compartilhado entre perfil e alunos

## Bug encontrado e corrigido durante o teste
`MoleculeAlunosTable`'s `formatDate` sofria deslocamento de 1 dia nas datas de nascimento (parsing UTC vs. local de strings `yyyy-MM-dd`) — corrigido pra extrair os componentes da data direto da string, sem depender do fuso do browser.

## Commits
- fix: corrige leitura da mensagem de erro do backend no login e cadastro
- feat: adiciona service e handlers de alunos
- feat: adiciona validação e configuração de inputs do formulário de aluno
- feat: adiciona composables de listagem e formulário de alunos
- refactor: extrai isFormValid para util compartilhado
- feat: adiciona tabela de alunos
- feat: implementa tela de gerenciamento de alunos