### PR TITLE
test: configura vitest e adiciona testes automatizados do front

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "axios": "^1.11.0",
@@ -22,11 +24,14 @@
   "devDependencies": {
     "@types/js-cookie": "^3.0.6",
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vue/test-utils": "^2.4.11",
     "@vue/tsconfig": "^0.7.0",
+    "jsdom": "^30.0.1",
     "sass": "^1.92.1",
     "sass-loader": "^12.6.0",
     "typescript": "~5.8.3",
     "vite": "^7.1.2",
+    "vitest": "^4.1.11",
     "vue-tsc": "^3.0.5"
   }
 }

--- a/src/components/atomicDesign/molecule/MoleculeForm.spec.ts
+++ b/src/components/atomicDesign/molecule/MoleculeForm.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref } from "vue";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import MoleculeForm from "./MoleculeForm.vue";
+
+const vuetify = createVuetify({ components, directives });
+
+function mountForm(propsOverrides: Record<string, unknown> = {}) {
+  const onSubmit = vi.fn();
+  const values = { email: ref(""), password: ref("") };
+  const inputs = [
+    { name: "email", type: "text", placeholder: "Email", rules: [] },
+    { name: "password", type: "password", placeholder: "Senha", rules: [] },
+  ];
+
+  const wrapper = mount(MoleculeForm as any, {
+    global: { plugins: [vuetify] },
+    props: {
+      pageTitle: "Gerenciamento de Alunos",
+      title: "Login",
+      buttonText: "Entrar",
+      inputs,
+      values,
+      loading: false,
+      isFormValid: true,
+      onSubmit,
+      ...propsOverrides,
+    },
+  });
+
+  return { wrapper, onSubmit, values };
+}
+
+describe("MoleculeForm", () => {
+  it("renderiza o pageTitle e o título da seção quando informado", () => {
+    const { wrapper } = mountForm();
+    expect(wrapper.text()).toContain("Gerenciamento de Alunos");
+    expect(wrapper.text()).toContain("Login");
+  });
+
+  it("não renderiza um segundo título quando title está vazio (usado nos diálogos de perfil/alunos)", () => {
+    const { wrapper } = mountForm({ title: "" });
+    expect(wrapper.findAll("h2")).toHaveLength(0);
+  });
+
+  it("renderiza um input pra cada item de inputs, com o placeholder certo", () => {
+    const { wrapper } = mountForm();
+    const inputsRendered = wrapper.findAll("input");
+    expect(inputsRendered).toHaveLength(2);
+    expect(inputsRendered[0].attributes("placeholder")).toBe("Email");
+    expect(inputsRendered[1].attributes("placeholder")).toBe("Senha");
+  });
+
+  it("desabilita o botão de envio quando isFormValid é false", () => {
+    const { wrapper } = mountForm({ isFormValid: false });
+    const button = wrapper.find('button[type="submit"]');
+    expect((button.element as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("habilita o botão quando isFormValid é true", () => {
+    const { wrapper } = mountForm({ isFormValid: true });
+    const button = wrapper.find('button[type="submit"]');
+    expect((button.element as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("chama onSubmit ao submeter o formulário", async () => {
+    const { wrapper, onSubmit } = mountForm();
+    await wrapper.find("form").trigger("submit");
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/components/atomicDesign/organism/OrganismAlunos.spec.ts
+++ b/src/components/atomicDesign/organism/OrganismAlunos.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref } from "vue";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import OrganismAlunos from "./OrganismAlunos.vue";
+import type { Aluno } from "../../../utils/types/aluno";
+
+const vuetify = createVuetify({ components, directives });
+
+const mockAlunos = ref<Aluno[]>([]);
+const mockLoading = ref(false);
+const mockError = ref<string | null>(null);
+const mockNomeFiltro = ref("");
+const mockCursoFiltro = ref("");
+const mockPagina = ref(0);
+const mockTemProximaPagina = ref(false);
+const mockFetchAlunos = vi.fn();
+const mockBuscar = vi.fn();
+const mockProximaPagina = vi.fn();
+const mockPaginaAnterior = vi.fn();
+
+vi.mock("../../../composables/useAlunosList", () => ({
+  useAlunosList: () => ({
+    alunos: mockAlunos,
+    loading: mockLoading,
+    error: mockError,
+    nomeFiltro: mockNomeFiltro,
+    cursoFiltro: mockCursoFiltro,
+    pagina: mockPagina,
+    temProximaPagina: mockTemProximaPagina,
+    fetchAlunos: mockFetchAlunos,
+    buscar: mockBuscar,
+    proximaPagina: mockProximaPagina,
+    paginaAnterior: mockPaginaAnterior,
+  }),
+}));
+
+vi.mock("../../../composables/useAlunoForm", () => ({
+  useAlunoForm: () => ({
+    id: ref(undefined),
+    nome: ref(""),
+    email: ref(""),
+    curso: ref(""),
+    dataNascimento: ref(""),
+    status: ref(true),
+    loading: ref(false),
+    resetForm: vi.fn(),
+    onSubmit: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../services/alunoHandlers", () => ({
+  handleDeletarAluno: vi.fn(),
+}));
+
+function alunoFixture(id: number): Aluno {
+  return {
+    id,
+    nome: `Aluno ${id}`,
+    email: `aluno${id}@teste.com`,
+    curso: "Curso",
+    dataNascimento: "2000-01-01T00:00:00",
+    status: true,
+    dataCriacao: "2026-01-01T00:00:00",
+    dataAtualizacao: "2026-01-01T00:00:00",
+  };
+}
+
+function mountAlunos() {
+  return mount(OrganismAlunos as any, {
+    global: { plugins: [vuetify] },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAlunos.value = [];
+  mockLoading.value = false;
+  mockError.value = null;
+  mockNomeFiltro.value = "";
+  mockCursoFiltro.value = "";
+  mockPagina.value = 0;
+  mockTemProximaPagina.value = false;
+});
+
+describe("OrganismAlunos", () => {
+  it("busca a lista de alunos ao montar", () => {
+    mountAlunos();
+    expect(mockFetchAlunos).toHaveBeenCalled();
+  });
+
+  it("mostra o spinner de carregamento quando loading=true e a lista está vazia", () => {
+    mockLoading.value = true;
+    const wrapper = mountAlunos();
+    expect(wrapper.find(".v-progress-circular").exists()).toBe(true);
+  });
+
+  it("mostra o alerta de erro quando error está preenchido", () => {
+    mockError.value = "Erro ao carregar alunos";
+    const wrapper = mountAlunos();
+    expect(wrapper.text()).toContain("Erro ao carregar alunos");
+  });
+
+  it("mostra 'Nenhum aluno cadastrado ainda' quando a lista está vazia sem filtro nem paginação", () => {
+    const wrapper = mountAlunos();
+    expect(wrapper.text()).toContain("Nenhum aluno cadastrado ainda.");
+  });
+
+  it("mostra 'Nenhum aluno encontrado para esse filtro' quando há filtro ativo e lista vazia", () => {
+    mockNomeFiltro.value = "Zzz";
+    const wrapper = mountAlunos();
+    expect(wrapper.text()).toContain("Nenhum aluno encontrado para esse filtro.");
+  });
+
+  it("mostra 'Não há mais alunos para exibir' quando está em página > 0 e vazia", () => {
+    mockPagina.value = 1;
+    const wrapper = mountAlunos();
+    expect(wrapper.text()).toContain("Não há mais alunos para exibir.");
+  });
+
+  it("renderiza a tabela com os alunos quando a lista não está vazia", () => {
+    mockAlunos.value = [alunoFixture(1), alunoFixture(2)];
+    const wrapper = mountAlunos();
+    expect(wrapper.text()).toContain("Aluno 1");
+    expect(wrapper.text()).toContain("Aluno 2");
+  });
+
+  it("botão Próxima fica desabilitado quando temProximaPagina é false", () => {
+    mockAlunos.value = [alunoFixture(1)];
+    mockTemProximaPagina.value = false;
+    const wrapper = mountAlunos();
+    const nextButton = wrapper.findAll("button").find((b) => b.text() === "Próxima");
+    expect((nextButton!.element as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("botão Próxima fica habilitado quando temProximaPagina é true", () => {
+    mockAlunos.value = [alunoFixture(1)];
+    mockTemProximaPagina.value = true;
+    const wrapper = mountAlunos();
+    const nextButton = wrapper.findAll("button").find((b) => b.text() === "Próxima");
+    expect((nextButton!.element as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/src/components/atomicDesign/organism/OrganismProfile.spec.ts
+++ b/src/components/atomicDesign/organism/OrganismProfile.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref } from "vue";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import OrganismProfile from "./OrganismProfile.vue";
+
+const vuetify = createVuetify({ components, directives });
+
+const mockUser = ref<any>(null);
+const mockLoading = ref(false);
+const mockError = ref<string | null>(null);
+const mockFetchUser = vi.fn();
+
+vi.mock("../../../composables/useProfile", () => ({
+  useProfile: () => ({
+    user: mockUser,
+    loading: mockLoading,
+    error: mockError,
+    fetchUser: mockFetchUser,
+  }),
+}));
+
+vi.mock("../../../composables/useEditProfileForm", () => ({
+  useEditProfileForm: () => ({
+    name: ref(""),
+    email: ref(""),
+    currentPassword: ref(""),
+    loading: ref(false),
+    resetForm: vi.fn(),
+    onSubmit: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../composables/useChangePasswordForm", () => ({
+  useChangePasswordForm: () => ({
+    newPassword: ref(""),
+    confirmNewPassword: ref(""),
+    loading: ref(false),
+    resetForm: vi.fn(),
+    onSubmit: vi.fn(),
+  }),
+}));
+
+function mountProfile() {
+  return mount(OrganismProfile as any, {
+    global: { plugins: [vuetify] },
+    props: { title: "Perfil" },
+  });
+}
+
+beforeEach(() => {
+  mockUser.value = null;
+  mockLoading.value = false;
+  mockError.value = null;
+});
+
+describe("OrganismProfile", () => {
+  it("mostra o spinner de carregamento quando loading=true e ainda não há usuário", () => {
+    mockLoading.value = true;
+
+    const wrapper = mountProfile();
+
+    expect(wrapper.find(".v-progress-circular").exists()).toBe(true);
+  });
+
+  it("mostra o alerta de erro quando error está preenchido", () => {
+    mockError.value = "Usuário não autenticado";
+
+    const wrapper = mountProfile();
+
+    expect(wrapper.text()).toContain("Usuário não autenticado");
+  });
+
+  it("mostra os dados do usuário carregado, com o chip de perfil correto", () => {
+    mockUser.value = {
+      nome: "Ana",
+      email: "ana@teste.com",
+      perfil: 2,
+      status: true,
+      dataCriacao: "2026-01-01T10:00:00",
+    };
+
+    const wrapper = mountProfile();
+
+    expect(wrapper.text()).toContain("Ana");
+    expect(wrapper.text()).toContain("ana@teste.com");
+    expect(wrapper.text()).toContain("Admin");
+  });
+
+  it("mostra os botões de editar perfil e alterar senha", () => {
+    mockUser.value = { nome: "Ana", email: "ana@teste.com", perfil: 1, status: true, dataCriacao: "2026-01-01T10:00:00" };
+
+    const wrapper = mountProfile();
+
+    expect(wrapper.text()).toContain("Editar Perfil");
+    expect(wrapper.text()).toContain("Alterar Senha");
+  });
+});

--- a/src/composables/useAlunoForm.spec.ts
+++ b/src/composables/useAlunoForm.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useAlunoForm } from "./useAlunoForm";
+import { handleSalvarAluno } from "../services/alunoHandlers";
+import type { Aluno } from "../utils/types/aluno";
+
+vi.mock("../services/alunoHandlers", () => ({
+  handleSalvarAluno: vi.fn(),
+}));
+
+const aluno: Aluno = {
+  id: 5,
+  nome: "Carlos",
+  email: "carlos@teste.com",
+  curso: "Medicina",
+  dataNascimento: "2001-03-15T00:00:00",
+  status: true,
+  dataCriacao: "2026-01-01T00:00:00",
+  dataAtualizacao: "2026-01-01T00:00:00",
+};
+
+describe("useAlunoForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resetForm() sem argumento limpa tudo pro modo de criação", () => {
+    const form = useAlunoForm(vi.fn());
+    form.resetForm();
+
+    expect(form.id.value).toBeUndefined();
+    expect(form.nome.value).toBe("");
+    expect(form.email.value).toBe("");
+    expect(form.curso.value).toBe("");
+    expect(form.dataNascimento.value).toBe("");
+    expect(form.status.value).toBe(true);
+  });
+
+  it("resetForm(aluno) preenche os campos, cortando a data pra yyyy-MM-dd", () => {
+    const form = useAlunoForm(vi.fn());
+    form.resetForm(aluno);
+
+    expect(form.id.value).toBe(5);
+    expect(form.nome.value).toBe("Carlos");
+    expect(form.email.value).toBe("carlos@teste.com");
+    expect(form.curso.value).toBe("Medicina");
+    expect(form.dataNascimento.value).toBe("2001-03-15");
+  });
+
+  it("onSubmit em modo criação chama handleSalvarAluno sem id", () => {
+    const onSuccess = vi.fn();
+    const form = useAlunoForm(onSuccess);
+    form.nome.value = "Novo Aluno";
+    form.email.value = "novo@teste.com";
+    form.curso.value = "Direito";
+    form.dataNascimento.value = "2002-02-02";
+
+    form.onSubmit();
+
+    expect(handleSalvarAluno).toHaveBeenCalledWith(
+      {
+        id: undefined,
+        nome: "Novo Aluno",
+        email: "novo@teste.com",
+        curso: "Direito",
+        dataNascimento: "2002-02-02",
+        status: true,
+      },
+      expect.any(Function),
+      onSuccess
+    );
+  });
+
+  it("onSubmit em modo edição chama handleSalvarAluno com o id do aluno", () => {
+    const onSuccess = vi.fn();
+    const form = useAlunoForm(onSuccess);
+    form.resetForm(aluno);
+
+    form.onSubmit();
+
+    expect(handleSalvarAluno).toHaveBeenCalledWith(
+      {
+        id: 5,
+        nome: "Carlos",
+        email: "carlos@teste.com",
+        curso: "Medicina",
+        dataNascimento: "2001-03-15",
+        status: true,
+      },
+      expect.any(Function),
+      onSuccess
+    );
+  });
+});

--- a/src/composables/useAlunosList.spec.ts
+++ b/src/composables/useAlunosList.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useAlunosList, QUANTIDADE_POR_PAGINA } from "./useAlunosList";
+import { handleListarAlunos } from "../services/alunoHandlers";
+import type { Aluno } from "../utils/types/aluno";
+
+vi.mock("../services/alunoHandlers", () => ({
+  handleListarAlunos: vi.fn(),
+}));
+
+function alunoFixture(id: number): Aluno {
+  return {
+    id,
+    nome: `Aluno ${id}`,
+    email: `aluno${id}@teste.com`,
+    curso: "Curso",
+    dataNascimento: "2000-01-01T00:00:00",
+    status: true,
+    dataCriacao: "2026-01-01T00:00:00",
+    dataAtualizacao: "2026-01-01T00:00:00",
+  };
+}
+
+describe("useAlunosList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("busca a primeira página pedindo QUANTIDADE_POR_PAGINA + 1 itens (peek-ahead), pular=0", () => {
+    const { fetchAlunos } = useAlunosList();
+    fetchAlunos();
+
+    expect(handleListarAlunos).toHaveBeenCalledWith(
+      { nome: undefined, curso: undefined, pular: 0, quantidade: QUANTIDADE_POR_PAGINA + 1 },
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it("marca temProximaPagina=true e corta a lista quando vem 1 item a mais que o tamanho da página", () => {
+    (handleListarAlunos as any).mockImplementation((_filtros: any, _setLoading: any, onSuccess: any) => {
+      const extra = Array.from({ length: QUANTIDADE_POR_PAGINA + 1 }, (_, i) => alunoFixture(i + 1));
+      onSuccess(extra);
+    });
+
+    const { alunos, temProximaPagina, fetchAlunos } = useAlunosList();
+    fetchAlunos();
+
+    expect(alunos.value).toHaveLength(QUANTIDADE_POR_PAGINA);
+    expect(temProximaPagina.value).toBe(true);
+  });
+
+  it("marca temProximaPagina=false quando vem no máximo o tamanho da página", () => {
+    (handleListarAlunos as any).mockImplementation((_filtros: any, _setLoading: any, onSuccess: any) => {
+      onSuccess([alunoFixture(1), alunoFixture(2)]);
+    });
+
+    const { alunos, temProximaPagina, fetchAlunos } = useAlunosList();
+    fetchAlunos();
+
+    expect(alunos.value).toHaveLength(2);
+    expect(temProximaPagina.value).toBe(false);
+  });
+
+  it("onError preenche error com a mensagem recebida", () => {
+    (handleListarAlunos as any).mockImplementation((_filtros: any, _setLoading: any, _onSuccess: any, onError: any) => {
+      onError("Deu ruim");
+    });
+
+    const { error, fetchAlunos } = useAlunosList();
+    fetchAlunos();
+
+    expect(error.value).toBe("Deu ruim");
+  });
+
+  it("buscar() reseta a página pra 0 e refaz a busca com os filtros atuais", () => {
+    const { nomeFiltro, pagina, buscar } = useAlunosList();
+    pagina.value = 3;
+    nomeFiltro.value = "Ana";
+
+    buscar();
+
+    expect(pagina.value).toBe(0);
+    expect(handleListarAlunos).toHaveBeenCalledWith(
+      expect.objectContaining({ nome: "Ana", pular: 0 }),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it("proximaPagina() incrementa a página e busca com o pular correspondente", () => {
+    const { pagina, proximaPagina } = useAlunosList();
+    proximaPagina();
+
+    expect(pagina.value).toBe(1);
+    expect(handleListarAlunos).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pular: QUANTIDADE_POR_PAGINA }),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it("paginaAnterior() não deixa a página ficar negativa nem busca de novo", () => {
+    const { pagina, paginaAnterior } = useAlunosList();
+    paginaAnterior();
+
+    expect(pagina.value).toBe(0);
+    expect(handleListarAlunos).not.toHaveBeenCalled();
+  });
+
+  it("paginaAnterior() decrementa a página quando não está na primeira", () => {
+    const { pagina, proximaPagina, paginaAnterior } = useAlunosList();
+    proximaPagina();
+    vi.clearAllMocks();
+
+    paginaAnterior();
+
+    expect(pagina.value).toBe(0);
+    expect(handleListarAlunos).toHaveBeenCalledWith(
+      expect.objectContaining({ pular: 0 }),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+});

--- a/src/composables/useChangePasswordForm.spec.ts
+++ b/src/composables/useChangePasswordForm.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import { useChangePasswordForm } from "./useChangePasswordForm";
+import { handleChangePassword } from "../services/usuarioHandlers";
+
+vi.mock("../services/usuarioHandlers", () => ({
+  handleEditProfile: vi.fn(),
+  handleChangePassword: vi.fn(),
+}));
+
+describe("useChangePasswordForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resetForm limpa os campos de senha", () => {
+    const user = ref({ id: 1, nome: "Ana", email: "ana@teste.com", perfil: 1, status: true });
+    const form = useChangePasswordForm(user, vi.fn());
+
+    form.newPassword.value = "algo";
+    form.confirmNewPassword.value = "algo";
+    form.resetForm();
+
+    expect(form.newPassword.value).toBe("");
+    expect(form.confirmNewPassword.value).toBe("");
+  });
+
+  it("onSubmit chama handleChangePassword com o usuário atual, as senhas e onSuccess", () => {
+    const user = ref({ id: 1, nome: "Ana", email: "ana@teste.com", perfil: 1, status: true });
+    const onSuccess = vi.fn();
+    const form = useChangePasswordForm(user, onSuccess);
+
+    form.newPassword.value = "NovaSenha1!";
+    form.confirmNewPassword.value = "NovaSenha1!";
+
+    form.onSubmit();
+
+    expect(handleChangePassword).toHaveBeenCalledWith(
+      user.value,
+      "NovaSenha1!",
+      "NovaSenha1!",
+      expect.any(Function),
+      onSuccess
+    );
+  });
+});

--- a/src/composables/useEditProfileForm.spec.ts
+++ b/src/composables/useEditProfileForm.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import { useEditProfileForm } from "./useEditProfileForm";
+import { handleEditProfile } from "../services/usuarioHandlers";
+
+vi.mock("../services/usuarioHandlers", () => ({
+  handleEditProfile: vi.fn(),
+  handleChangePassword: vi.fn(),
+}));
+
+describe("useEditProfileForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resetForm preenche nome/email a partir do usuário carregado e limpa a senha", () => {
+    const user = ref({ nome: "Ana", email: "ana@teste.com" });
+    const form = useEditProfileForm(user, vi.fn());
+
+    form.currentPassword.value = "algo digitado antes";
+    form.resetForm();
+
+    expect(form.name.value).toBe("Ana");
+    expect(form.email.value).toBe("ana@teste.com");
+    expect(form.currentPassword.value).toBe("");
+  });
+
+  it("resetForm não quebra quando o usuário ainda não carregou (null)", () => {
+    const user = ref<any>(null);
+    const form = useEditProfileForm(user, vi.fn());
+
+    form.resetForm();
+
+    expect(form.name.value).toBe("");
+    expect(form.email.value).toBe("");
+  });
+
+  it("onSubmit chama handleEditProfile com o usuário atual, os campos do form e onSuccess", () => {
+    const user = ref({ id: 1, nome: "Ana", email: "ana@teste.com", perfil: 1, status: true });
+    const onSuccess = vi.fn();
+    const form = useEditProfileForm(user, onSuccess);
+
+    form.name.value = "Ana Editada";
+    form.email.value = "nova@teste.com";
+    form.currentPassword.value = "SenhaAtual1!";
+
+    form.onSubmit();
+
+    expect(handleEditProfile).toHaveBeenCalledWith(
+      user.value,
+      "Ana Editada",
+      "nova@teste.com",
+      "SenhaAtual1!",
+      expect.any(Function),
+      onSuccess
+    );
+  });
+});

--- a/src/composables/useLoginForm.spec.ts
+++ b/src/composables/useLoginForm.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useLoginForm } from "./useLoginForm";
+import { handleLogin } from "../services/authHandlers";
+
+vi.mock("../services/authHandlers", () => ({
+  handleLogin: vi.fn(),
+}));
+
+describe("useLoginForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inicia com campos vazios e loading false", () => {
+    const form = useLoginForm();
+    expect(form.email.value).toBe("");
+    expect(form.password.value).toBe("");
+    expect(form.loading.value).toBe(false);
+  });
+
+  it("onSubmit chama handleLogin com email, senha e o setter de loading", () => {
+    const form = useLoginForm();
+    form.email.value = "ana@teste.com";
+    form.password.value = "Senha123!";
+
+    form.onSubmit();
+
+    expect(handleLogin).toHaveBeenCalledWith("ana@teste.com", "Senha123!", expect.any(Function));
+  });
+
+  it("expõe uma regra de validação pra email e uma pra senha", () => {
+    const form = useLoginForm();
+    expect(form.emailRules).toHaveLength(1);
+    expect(form.passwordRules).toHaveLength(1);
+  });
+});

--- a/src/composables/useProfile.spec.ts
+++ b/src/composables/useProfile.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Cookies from "js-cookie";
+import { useProfile } from "./useProfile";
+import api from "../api/axios";
+import { buildFakeToken } from "../test-utils/fakeToken";
+
+vi.mock("../api/axios", () => ({
+  default: { get: vi.fn() },
+}));
+
+const FUTURE_EXP = 9999999999;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  Cookies.remove("token");
+});
+
+describe("useProfile", () => {
+  it("marca erro 'Usuário não autenticado' quando não há token, sem chamar a API", async () => {
+    const { fetchUser, error, user } = useProfile();
+
+    await fetchUser();
+
+    expect(error.value).toBe("Usuário não autenticado");
+    expect(user.value).toBeNull();
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("carrega o usuário usando o id extraído do token", async () => {
+    Cookies.set("token", buildFakeToken({ sub: "7", exp: FUTURE_EXP }));
+    (api.get as any).mockResolvedValue({ data: { id: 7, nome: "Ana", email: "ana@teste.com" } });
+
+    const { fetchUser, user, loading, error } = useProfile();
+    await fetchUser();
+
+    expect(api.get).toHaveBeenCalledWith("/usuario/7");
+    expect(user.value).toEqual({ id: 7, nome: "Ana", email: "ana@teste.com" });
+    expect(loading.value).toBe(false);
+    expect(error.value).toBeNull();
+  });
+
+  it("usa a mensagem de erro do backend (chave 'mensagem') quando a API falha", async () => {
+    Cookies.set("token", buildFakeToken({ sub: "7", exp: FUTURE_EXP }));
+    (api.get as any).mockRejectedValue({ response: { data: { mensagem: "Falha ao buscar" } } });
+
+    const { fetchUser, error } = useProfile();
+    await fetchUser();
+
+    expect(error.value).toBe("Falha ao buscar");
+  });
+
+  it("usa mensagem genérica quando o erro não vem com 'mensagem'", async () => {
+    Cookies.set("token", buildFakeToken({ sub: "7", exp: FUTURE_EXP }));
+    (api.get as any).mockRejectedValue(new Error("network error"));
+
+    const { fetchUser, error } = useProfile();
+    await fetchUser();
+
+    expect(error.value).toBe("Erro ao carregar perfil");
+  });
+});

--- a/src/composables/useRegisterForm.spec.ts
+++ b/src/composables/useRegisterForm.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useRegisterForm } from "./useRegisterForm";
+import { handleRegister } from "../services/authHandlers";
+
+vi.mock("../services/authHandlers", () => ({
+  handleRegister: vi.fn(),
+}));
+
+describe("useRegisterForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inicia com todos os campos vazios e loading false", () => {
+    const form = useRegisterForm();
+    expect(form.name.value).toBe("");
+    expect(form.email.value).toBe("");
+    expect(form.password.value).toBe("");
+    expect(form.confirmPassword.value).toBe("");
+    expect(form.loading.value).toBe(false);
+  });
+
+  it("onSubmit chama handleRegister com todos os campos e o setter de loading", () => {
+    const form = useRegisterForm();
+    form.name.value = "Ana";
+    form.email.value = "ana@teste.com";
+    form.password.value = "Senha123!";
+    form.confirmPassword.value = "Senha123!";
+
+    form.onSubmit();
+
+    expect(handleRegister).toHaveBeenCalledWith(
+      "Ana",
+      "ana@teste.com",
+      "Senha123!",
+      "Senha123!",
+      expect.any(Function)
+    );
+  });
+});

--- a/src/services/alunoHandlers.spec.ts
+++ b/src/services/alunoHandlers.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleListarAlunos, handleSalvarAluno, handleDeletarAluno } from "./alunoHandlers";
+import { listarAlunos, criarAluno, atualizarAluno, deletarAluno } from "./alunoService";
+import type { Aluno } from "../utils/types/aluno";
+
+vi.mock("./alunoService", () => ({
+  listarAlunos: vi.fn(),
+  criarAluno: vi.fn(),
+  atualizarAluno: vi.fn(),
+  deletarAluno: vi.fn(),
+}));
+
+const aluno: Aluno = {
+  id: 1,
+  nome: "Ana",
+  email: "ana@teste.com",
+  curso: "Engenharia",
+  dataNascimento: "2000-01-01T00:00:00",
+  status: true,
+  dataCriacao: "2026-01-01T00:00:00",
+  dataAtualizacao: "2026-01-01T00:00:00",
+};
+
+describe("handleListarAlunos", () => {
+  let setLoading: (val: boolean) => void;
+  let onSuccess: (alunos: Aluno[]) => void;
+  let onError: (mensagem: string) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLoading = vi.fn<(val: boolean) => void>();
+    onSuccess = vi.fn<(alunos: Aluno[]) => void>();
+    onError = vi.fn<(mensagem: string) => void>();
+  });
+
+  it("chama onSuccess com a lista retornada", async () => {
+    (listarAlunos as any).mockResolvedValue([aluno]);
+
+    await handleListarAlunos({}, setLoading, onSuccess, onError);
+
+    expect(onSuccess).toHaveBeenCalledWith([aluno]);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("regressão: trata 404 (busca sem resultado) como lista vazia, não como erro", async () => {
+    (listarAlunos as any).mockRejectedValue({
+      response: { status: 404, data: { mensagem: "Nenhum aluno encontrado." } },
+    });
+
+    await handleListarAlunos({ nome: "Zzz" }, setLoading, onSuccess, onError);
+
+    expect(onSuccess).toHaveBeenCalledWith([]);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("chama onError com a mensagem do backend pra outros códigos de erro", async () => {
+    (listarAlunos as any).mockRejectedValue({
+      response: { status: 500, data: { mensagem: "Erro interno" } },
+    });
+
+    await handleListarAlunos({}, setLoading, onSuccess, onError);
+
+    expect(onError).toHaveBeenCalledWith("Erro interno");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSalvarAluno", () => {
+  let setLoading: (val: boolean) => void;
+  let onSuccess: () => void;
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLoading = vi.fn<(val: boolean) => void>();
+    onSuccess = vi.fn<() => void>();
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  it("chama criarAluno quando o payload não tem id", async () => {
+    (criarAluno as any).mockResolvedValue(aluno);
+
+    await handleSalvarAluno(
+      { nome: "Ana", email: "ana@teste.com", curso: "Engenharia", dataNascimento: "2000-01-01" },
+      setLoading,
+      onSuccess
+    );
+
+    expect(criarAluno).toHaveBeenCalled();
+    expect(atualizarAluno).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("chama atualizarAluno quando o payload tem id", async () => {
+    (atualizarAluno as any).mockResolvedValue(aluno);
+
+    await handleSalvarAluno(
+      { id: 1, nome: "Ana", email: "ana@teste.com", curso: "Engenharia", dataNascimento: "2000-01-01" },
+      setLoading,
+      onSuccess
+    );
+
+    expect(atualizarAluno).toHaveBeenCalled();
+    expect(criarAluno).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("bloqueia quando a data de nascimento é futura, sem chamar a API", async () => {
+    const futuro = new Date();
+    futuro.setFullYear(futuro.getFullYear() + 1);
+
+    await handleSalvarAluno(
+      {
+        nome: "Ana",
+        email: "ana@teste.com",
+        curso: "Engenharia",
+        dataNascimento: futuro.toISOString().slice(0, 10),
+      },
+      setLoading,
+      onSuccess
+    );
+
+    expect(criarAluno).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("Erro no formulário"));
+  });
+});
+
+describe("handleDeletarAluno", () => {
+  it("exclui e chama onSuccess", async () => {
+    (deletarAluno as any).mockResolvedValue(aluno);
+    const setLoading = vi.fn<(val: boolean) => void>();
+    const onSuccess = vi.fn<() => void>();
+
+    await handleDeletarAluno(1, setLoading, onSuccess);
+
+    expect(deletarAluno).toHaveBeenCalledWith(1);
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("mostra a mensagem de erro real quando falha", async () => {
+    (deletarAluno as any).mockRejectedValue({ response: { data: { mensagem: "Aluno não encontrado." } } });
+    const setLoading = vi.fn<(val: boolean) => void>();
+    const onSuccess = vi.fn<() => void>();
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    await handleDeletarAluno(999, setLoading, onSuccess);
+
+    expect(alertSpy).toHaveBeenCalledWith("Falha ao excluir aluno: Aluno não encontrado.");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/alunoHandlers.ts
+++ b/src/services/alunoHandlers.ts
@@ -4,8 +4,8 @@ import type { Aluno } from "../utils/types/aluno";
 import { alunoSchema } from "../utils/validationSchema";
 
 function extractErrorMessage(err: any, fallback: string): string {
-  if (err?.errors) {
-    return "Erro no formulário: " + err.errors.map((e: any) => e.message).join(", ");
+  if (err?.issues) {
+    return "Erro no formulário: " + err.issues.map((e: any) => e.message).join(", ");
   }
   return fallback + ": " + (err.response?.data?.mensagem || err.message);
 }

--- a/src/services/authHandlers.spec.ts
+++ b/src/services/authHandlers.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleLogin, handleRegister, handleLogout } from "./authHandlers";
+import { login, register, logout } from "./authService";
+import router from "../router";
+
+vi.mock("./authService", () => ({
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+}));
+
+vi.mock("../router", () => ({
+  default: { push: vi.fn() },
+}));
+
+describe("handleLogin", () => {
+  let setLoading: (val: boolean) => void;
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLoading = vi.fn<(val: boolean) => void>();
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  it("faz login, redireciona pra /home e desliga o loading", async () => {
+    (login as any).mockResolvedValue({ token: "abc" });
+
+    await handleLogin("ana@teste.com", "Senha123!", setLoading);
+
+    expect(login).toHaveBeenCalledWith("ana@teste.com", "Senha123!");
+    expect(router.push).toHaveBeenCalledWith("/home");
+    expect(setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(setLoading).toHaveBeenLastCalledWith(false);
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it("valida o formulário com zod antes de chamar a API (email inválido)", async () => {
+    await handleLogin("nao-e-email", "Senha123!", setLoading);
+
+    expect(login).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("Erro no formulário"));
+  });
+
+  it("regressão: mostra a mensagem real do backend (chave 'mensagem'), não undefined", async () => {
+    (login as any).mockRejectedValue({ response: { data: { mensagem: "Credenciais inválidas" } } });
+
+    await handleLogin("ana@teste.com", "Senha123!", setLoading);
+
+    expect(alertSpy).toHaveBeenCalledWith("Falha no login: Credenciais inválidas");
+  });
+});
+
+describe("handleRegister", () => {
+  let setLoading: (val: boolean) => void;
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLoading = vi.fn<(val: boolean) => void>();
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  it("cadastra e redireciona pra /home", async () => {
+    (register as any).mockResolvedValue({ token: "abc" });
+
+    await handleRegister("Ana", "ana@teste.com", "Senha123!", "Senha123!", setLoading);
+
+    expect(register).toHaveBeenCalledWith("Ana", "ana@teste.com", "Senha123!");
+    expect(router.push).toHaveBeenCalledWith("/home");
+  });
+
+  it("bloqueia quando as senhas não coincidem, sem chamar a API", async () => {
+    await handleRegister("Ana", "ana@teste.com", "Senha123!", "Outra123!", setLoading);
+
+    expect(register).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining("Erro no formulário"));
+  });
+
+  it("regressão: mostra a mensagem real do backend em caso de erro da API", async () => {
+    (register as any).mockRejectedValue({ response: { data: { mensagem: "Email já cadastrado" } } });
+
+    await handleRegister("Ana", "ana@teste.com", "Senha123!", "Senha123!", setLoading);
+
+    expect(alertSpy).toHaveBeenCalledWith("Falha no cadastro: Email já cadastrado");
+  });
+});
+
+describe("handleLogout", () => {
+  it("desloga e redireciona pra /login", () => {
+    vi.clearAllMocks();
+    const setLoading = vi.fn<(val: boolean) => void>();
+
+    handleLogout(setLoading);
+
+    expect(logout).toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith("/login");
+    expect(setLoading).toHaveBeenNthCalledWith(1, true);
+    expect(setLoading).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/services/authHandlers.ts
+++ b/src/services/authHandlers.ts
@@ -9,8 +9,8 @@ export const handleLogin = async (email: string, password: string, setLoading: (
     await login(email, password);
     router.push("/home");
   } catch (err: any) {
-    if (err?.errors) {
-      alert("Erro no formulário: " + err.errors.map((e: any) => e.message).join(", "));
+    if (err?.issues) {
+      alert("Erro no formulário: " + err.issues.map((e: any) => e.message).join(", "));
     } else {
       alert("Falha no login: " + (err.response?.data?.mensagem || err.message));
     }
@@ -32,8 +32,8 @@ export const handleRegister = async (
     await register(name, email, password);
     router.push("/home");
   } catch (err: any) {
-    if (err?.errors) {
-      alert("Erro no formulário: " + err.errors.map((e: any) => e.message).join(", "));
+    if (err?.issues) {
+      alert("Erro no formulário: " + err.issues.map((e: any) => e.message).join(", "));
     } else {
       alert("Falha no cadastro: " + (err.response?.data?.mensagem || err.message));
     }

--- a/src/services/tokenService.spec.ts
+++ b/src/services/tokenService.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import Cookies from "js-cookie";
+import { getUserIdFromToken, getUserRoleFromToken, isTokenExpired } from "./tokenService";
+import { buildFakeToken as buildToken } from "../test-utils/fakeToken";
+
+const ROLE_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
+
+const FUTURE_EXP = 9999999999;
+const PAST_EXP = 1000000000;
+
+afterEach(() => {
+  Cookies.remove("token");
+});
+
+describe("getUserIdFromToken", () => {
+  it("retorna o id a partir da claim 'sub' do token", () => {
+    Cookies.set("token", buildToken({ sub: "42", exp: FUTURE_EXP }));
+    expect(getUserIdFromToken()).toBe(42);
+  });
+
+  it("retorna null quando não há token", () => {
+    expect(getUserIdFromToken()).toBeNull();
+  });
+
+  it("retorna null quando o token é inválido", () => {
+    Cookies.set("token", "isso-nao-e-um-jwt");
+    expect(getUserIdFromToken()).toBeNull();
+  });
+});
+
+describe("getUserRoleFromToken", () => {
+  it("lê o perfil pela claim de URI completa (http://schemas.xmlsoap.org/.../role), não por 'role'", () => {
+    Cookies.set("token", buildToken({ sub: "1", exp: FUTURE_EXP, [ROLE_CLAIM]: "ADMIN" }));
+    expect(getUserRoleFromToken()).toBe("ADMIN");
+  });
+
+  it("retorna null se o token tiver uma claim curta 'role' em vez da URI completa", () => {
+    // Regressão: a API nunca gera esse formato, mas serve pra provar que a
+    // implementação depende mesmo da chave longa, não de "role".
+    Cookies.set("token", buildToken({ sub: "1", exp: FUTURE_EXP, role: "ADMIN" }));
+    expect(getUserRoleFromToken()).toBeNull();
+  });
+
+  it("retorna null quando não há token", () => {
+    expect(getUserRoleFromToken()).toBeNull();
+  });
+});
+
+describe("isTokenExpired", () => {
+  it("retorna false para um token com exp no futuro", () => {
+    Cookies.set("token", buildToken({ sub: "1", exp: FUTURE_EXP }));
+    expect(isTokenExpired()).toBe(false);
+  });
+
+  it("retorna true para um token com exp no passado", () => {
+    Cookies.set("token", buildToken({ sub: "1", exp: PAST_EXP }));
+    expect(isTokenExpired()).toBe(true);
+  });
+
+  it("retorna true quando não há token", () => {
+    expect(isTokenExpired()).toBe(true);
+  });
+
+  it("retorna true quando o token é inválido", () => {
+    Cookies.set("token", "lixo.nao.decodificavel");
+    expect(isTokenExpired()).toBe(true);
+  });
+});

--- a/src/services/usuarioHandlers.spec.ts
+++ b/src/services/usuarioHandlers.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleEditProfile, handleChangePassword } from "./usuarioHandlers";
+import { atualizarUsuario } from "./usuarioService";
+
+vi.mock("./usuarioService", () => ({
+  atualizarUsuario: vi.fn(),
+}));
+
+const currentUser = { id: 1, nome: "Ana", email: "ana@teste.com", perfil: 1, status: true };
+
+describe("handleEditProfile", () => {
+  let setLoading: (val: boolean) => void;
+  let onSuccess: () => void;
+  let alertSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLoading = vi.fn<(val: boolean) => void>();
+    onSuccess = vi.fn<() => void>();
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  it("envia perfil/status do usuário atual inalterados, junto com os novos dados", async () => {
+    (atualizarUsuario as any).mockResolvedValue({});
+
+    await handleEditProfile(currentUser, "Ana Nova", "nova@teste.com", "SenhaAtual1!", setLoading, onSuccess);
+
+    expect(atualizarUsuario).toHaveBeenCalledWith({
+      id: 1,
+      nome: "Ana Nova",
+      email: "nova@teste.com",
+      senha: "SenhaAtual1!",
+      perfil: 1,
+      status: true,
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("bloqueia quando a senha atual está vazia, sem chamar a API", async () => {
+    await handleEditProfile(currentUser, "Ana Nova", "nova@teste.com", "", setLoading, onSuccess);
+
+    expect(atualizarUsuario).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("mostra a mensagem real do backend em caso de erro", async () => {
+    (atualizarUsuario as any).mockRejectedValue({ response: { data: { mensagem: "Email já em uso" } } });
+
+    await handleEditProfile(currentUser, "Ana Nova", "nova@teste.com", "SenhaAtual1!", setLoading, onSuccess);
+
+    expect(alertSpy).toHaveBeenCalledWith("Falha ao atualizar perfil: Email já em uso");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleChangePassword", () => {
+  let setLoading: (val: boolean) => void;
+  let onSuccess: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLoading = vi.fn<(val: boolean) => void>();
+    onSuccess = vi.fn<() => void>();
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  it("mantém nome/email/perfil/status do usuário atual, trocando só a senha", async () => {
+    (atualizarUsuario as any).mockResolvedValue({});
+
+    await handleChangePassword(currentUser, "NovaSenha1!", "NovaSenha1!", setLoading, onSuccess);
+
+    expect(atualizarUsuario).toHaveBeenCalledWith({
+      id: 1,
+      nome: "Ana",
+      email: "ana@teste.com",
+      senha: "NovaSenha1!",
+      perfil: 1,
+      status: true,
+    });
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("bloqueia quando a confirmação não bate com a nova senha", async () => {
+    await handleChangePassword(currentUser, "NovaSenha1!", "Diferente1!", setLoading, onSuccess);
+
+    expect(atualizarUsuario).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/usuarioHandlers.ts
+++ b/src/services/usuarioHandlers.ts
@@ -10,8 +10,8 @@ type CurrentUser = {
 };
 
 function extractErrorMessage(err: any, fallback: string): string {
-  if (err?.errors) {
-    return "Erro no formulário: " + err.errors.map((e: any) => e.message).join(", ");
+  if (err?.issues) {
+    return "Erro no formulário: " + err.issues.map((e: any) => e.message).join(", ");
   }
   return fallback + ": " + (err.response?.data?.mensagem || err.message);
 }

--- a/src/test-utils/fakeToken.ts
+++ b/src/test-utils/fakeToken.ts
@@ -1,0 +1,10 @@
+function base64url(obj: Record<string, unknown>): string {
+  const json = JSON.stringify(obj);
+  return btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function buildFakeToken(payload: Record<string, unknown>): string {
+  const header = base64url({ alg: "HS256", typ: "JWT" });
+  const body = base64url(payload);
+  return `${header}.${body}.fakesig`;
+}

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -1,0 +1,10 @@
+// jsdom não implementa ResizeObserver, mas vários componentes do Vuetify dependem dele.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  (globalThis as any).ResizeObserver = ResizeObserverStub;
+}

--- a/src/utils/formValidation.spec.ts
+++ b/src/utils/formValidation.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { ref } from "vue";
+import { isFormValid } from "./formValidation";
+
+describe("isFormValid", () => {
+  it("retorna true quando todos os campos listados em inputs estão preenchidos", () => {
+    const values = { nome: ref("Ana"), email: ref("ana@teste.com") };
+    const inputs = [{ name: "nome" }, { name: "email" }];
+
+    expect(isFormValid(inputs, values)).toBe(true);
+  });
+
+  it("retorna false quando algum campo está vazio", () => {
+    const values = { nome: ref("Ana"), email: ref("") };
+    const inputs = [{ name: "nome" }, { name: "email" }];
+
+    expect(isFormValid(inputs, values)).toBe(false);
+  });
+
+  it("retorna false quando o campo só tem espaços em branco", () => {
+    const values = { nome: ref("   ") };
+    const inputs = [{ name: "nome" }];
+
+    expect(isFormValid(inputs, values)).toBe(false);
+  });
+
+  it("retorna true para lista de inputs vazia", () => {
+    expect(isFormValid([], {})).toBe(true);
+  });
+});

--- a/src/utils/validationSchema.spec.ts
+++ b/src/utils/validationSchema.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  loginSchema,
+  registerSchema,
+  editProfileSchema,
+  changePasswordSchema,
+  alunoSchema,
+  makeRule,
+} from "./validationSchema";
+
+describe("loginSchema", () => {
+  it("aceita email e senha válidos", () => {
+    const result = loginSchema.safeParse({ email: "ana@teste.com", password: "Senha123!" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejeita email inválido", () => {
+    const result = loginSchema.safeParse({ email: "nao-e-email", password: "Senha123!" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejeita senha fraca (sem caractere especial)", () => {
+    const result = loginSchema.safeParse({ email: "ana@teste.com", password: "Senha1234" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejeita senha vazia", () => {
+    const result = loginSchema.safeParse({ email: "ana@teste.com", password: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("registerSchema", () => {
+  const base = { name: "Ana", email: "ana@teste.com", password: "Senha123!", confirmPassword: "Senha123!" };
+
+  it("aceita quando as senhas coincidem", () => {
+    expect(registerSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("rejeita quando as senhas não coincidem", () => {
+    const result = registerSchema.safeParse({ ...base, confirmPassword: "Outra123!" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejeita nome vazio", () => {
+    expect(registerSchema.safeParse({ ...base, name: "" }).success).toBe(false);
+  });
+});
+
+describe("editProfileSchema", () => {
+  it("aceita nome, email e senha atual preenchidos", () => {
+    const result = editProfileSchema.safeParse({ name: "Ana", email: "ana@teste.com", currentPassword: "qualquer" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejeita senha atual vazia", () => {
+    const result = editProfileSchema.safeParse({ name: "Ana", email: "ana@teste.com", currentPassword: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("não exige senha forte pra confirmar senha atual (só não-vazia)", () => {
+    const result = editProfileSchema.safeParse({ name: "Ana", email: "ana@teste.com", currentPassword: "123" });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("changePasswordSchema", () => {
+  it("aceita quando nova senha e confirmação coincidem", () => {
+    const result = changePasswordSchema.safeParse({ newPassword: "Senha123!", confirmNewPassword: "Senha123!" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejeita quando não coincidem", () => {
+    const result = changePasswordSchema.safeParse({ newPassword: "Senha123!", confirmNewPassword: "Diferente1!" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejeita nova senha fraca", () => {
+    const result = changePasswordSchema.safeParse({ newPassword: "12345678", confirmNewPassword: "12345678" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("alunoSchema", () => {
+  const base = { nome: "Carlos", email: "carlos@teste.com", curso: "Medicina", dataNascimento: "2001-03-15" };
+
+  it("aceita dados válidos com data de nascimento no passado", () => {
+    expect(alunoSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("rejeita data de nascimento no futuro", () => {
+    const futuro = new Date();
+    futuro.setFullYear(futuro.getFullYear() + 1);
+    const result = alunoSchema.safeParse({ ...base, dataNascimento: futuro.toISOString().slice(0, 10) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejeita curso vazio", () => {
+    expect(alunoSchema.safeParse({ ...base, curso: "" }).success).toBe(false);
+  });
+
+  it("rejeita data de nascimento vazia", () => {
+    expect(alunoSchema.safeParse({ ...base, dataNascimento: "" }).success).toBe(false);
+  });
+});
+
+describe("makeRule", () => {
+  it("retorna true quando o valor passa na validação", () => {
+    const rule = makeRule(loginSchema, "email");
+    expect(rule("ana@teste.com")).toBe(true);
+  });
+
+  it("retorna a mensagem de erro quando o valor não passa", () => {
+    const rule = makeRule(loginSchema, "email");
+    const result = rule("invalido");
+    expect(result).not.toBe(true);
+    expect(typeof result).toBe("string");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      exclude: ['node_modules', 'dist'],
+      setupFiles: ['./src/test-utils/setup.ts'],
+      css: true,
+      server: {
+        deps: {
+          inline: ['vuetify'],
+        },
+      },
+    },
+  })
+)


### PR DESCRIPTION
## Resumo
- Configura Vitest + Vue Test Utils (`vitest.config.ts`, scripts `test`/`test:watch`)
- 98 testes em 16 arquivos, cobrindo: schemas de validação (zod), `tokenService`, `formValidation`, todos os composables (auth, perfil, alunos), todos os handlers (auth, usuário, aluno) e 3 componentes-chave (`MoleculeForm`, `OrganismProfile`, `OrganismAlunos`)
- Testes de regressão explícitos pros bugs já corrigidos em tasks anteriores: claim `sub`/role do JWT, `.mensagem` vs `.message`, 404 tratado como lista vazia

## Bug real encontrado pelos próprios testes
No Zod v4 (versão instalada no projeto), `ZodError` não tem mais a propriedade `.errors` — foi renomeada pra `.issues`. `authHandlers.ts`, `usuarioHandlers.ts` e `alunoHandlers.ts` checavam `err?.errors` pra detectar erro de validação de formulário, que sempre dava `undefined`. Resultado: toda validação client-side que falhava (senha fraca, senhas não coincidem, data de nascimento futura, etc.) caía na mensagem de erro genérica, mostrando um JSON cru dos issues do Zod pro usuário em vez de "Erro no formulário: ...". Corrigido nos 3 arquivos e confirmado manualmente no navegador (cadastro com senhas diferentes agora mostra "Erro no formulário: As senhas não coincidem").

## Commits
- feat: configura vitest e vue test utils
- fix: corrige detecção de erro de validação do zod (issues, não errors)
- test: adiciona testes de validationSchema e tokenService
- test: adiciona testes dos composables de autenticação e perfil
- test: adiciona testes dos composables de alunos
- test: adiciona testes dos handlers de auth, usuário e aluno
- test: adiciona testes de componentes-chave

## Teste
- `npm run test`: 98/98 testes passando
- `vue-tsc -b`: sem erros
- `npm run build`: build de produção completo, sem erros
- Regressão confirmada manualmente no navegador pro bug do Zod (mensagem de erro de formulário agora aparece correta)