### PR TITLE
fix: acessar rota direto pela url dava 404 no vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Resumo
Vue Router usa createWebHistory (rotas "reais", sem #). Sem rewrite configurado, o Vercel não sabe que /register, /alunos, /perfil etc. devem cair no index.html — retorna 404 direto da borda antes do Vue Router sequer carregar. Adiciona vercel.json com rewrite catch-all.