### PR TITLE
fix: menu de admin nunca aparecia por causa da uri errada da claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ O login (`POST /Usuario/login`) retorna um JWT, guardado em cookie (`js-cookie`)
 
 O token carrega duas claims usadas pelo front:
 - **id do usuário** — claim padrão `sub`.
-- **perfil** (`USER`/`ADMIN`) — claim com a URI completa `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role` (não `role`), porque é assim que a API monta o token. Ver `src/services/tokenService.ts`.
+- **perfil** (`USER`/`ADMIN`) — claim com a URI completa `http://schemas.microsoft.com/ws/2008/06/identity/claims/role` (não `role`), porque é assim que a API monta o token. Ver `src/services/tokenService.ts`.
 
 Rotas protegidas (`src/router/index.ts`):
 - Qualquer rota sob `/` (exceto `/login` e `/register`) exige token válido — sem token ou com token expirado, redireciona pra `/login`.

--- a/src/services/tokenService.spec.ts
+++ b/src/services/tokenService.spec.ts
@@ -3,7 +3,7 @@ import Cookies from "js-cookie";
 import { getUserIdFromToken, getUserRoleFromToken, isTokenExpired } from "./tokenService";
 import { buildFakeToken as buildToken } from "../test-utils/fakeToken";
 
-const ROLE_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
+const ROLE_CLAIM = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
 
 const FUTURE_EXP = 9999999999;
 const PAST_EXP = 1000000000;
@@ -29,7 +29,7 @@ describe("getUserIdFromToken", () => {
 });
 
 describe("getUserRoleFromToken", () => {
-  it("lê o perfil pela claim de URI completa (http://schemas.xmlsoap.org/.../role), não por 'role'", () => {
+  it("lê o perfil pela claim de URI completa (http://schemas.microsoft.com/.../role), não por 'role'", () => {
     Cookies.set("token", buildToken({ sub: "1", exp: FUTURE_EXP, [ROLE_CLAIM]: "ADMIN" }));
     expect(getUserRoleFromToken()).toBe("ADMIN");
   });

--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -3,8 +3,10 @@ import { getToken } from "./authService";
 
 // A API monta o claim de perfil com Claim(ClaimTypes.Role, ...) e escreve o token
 // direto via `new JwtSecurityToken(issuer, audience, claims, ...)`, sem mapeamento
-// outbound — por isso a chave no payload é a URI completa, não "role".
-const ROLE_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role";
+// outbound — por isso a chave no payload é a URI completa que ClaimTypes.Role
+// realmente serializa (confirmado decodificando um token real gerado pela API em
+// produção), não "role" nem a URI do schema antigo do xmlsoap.org.
+const ROLE_CLAIM = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role";
 
 interface TokenPayload {
   sub: string;


### PR DESCRIPTION
## Resumo
getUserRoleFromToken() procurava a claim de perfil em http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role, mas a API (ClaimTypes.Role do .NET) realmente serializa em http://schemas.microsoft.com/ws/2008/06/identity/claims/role — confirmado decodificando um token real gerado em produção. Resultado: getUserRoleFromToken() sempre retornava null, então o menu de Alunos (adminOnly) nunca aparecia pra ninguém, nem pra admins de verdade.

O bug passava despercebido nos testes porque tokenService.spec.ts usava a MESMA uri errada tanto no token fake quanto na implementação — testava a implementação contra si mesma, nunca contra um token real da API.

## Test plan
- [x] npm run test -- --run tokenService (10/10)
- [x] npm run test -- --run (98/98, suite completa)
- [x] Confirmado decodificando um JWT real emitido pela API em produção — a claim vem exatamente com a URI microsoft.com